### PR TITLE
#679

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -3,15 +3,24 @@ const path = require('path')
 
 let iosutil = {
   asciiparser: function(key) {
-    switch (key) {
-      case 'enter':
-        return '\r'
-      case 'del':
-        return '\x08'
-      case 'home':
-        return null
-      default:
-        return key
+    switch (key) {           
+        case 'tab':
+          return '\x09'
+        case 'enter':
+          return '\r'
+        case 'del':
+          return '\x08'
+        // Disable keys (otherwise it sends the first character of key string on default case)
+        case 'dpad_left':
+        case 'dpad_up':
+        case 'dpad_right':
+        case 'dpad_down':
+        case 'caps_lock':
+        case 'escape':
+        case 'home':
+          return null
+        default:
+          return key
     }
   },
   degreesToOrientation: function(degree) {

--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -56,6 +56,10 @@ module.exports = syrup.serial()
         log.verbose("wire.TypeMessage: ", message)
         wdaClient.typeKey({value: [iosutil.asciiparser(message.text)]})
       })
+      .on(wire.KeyDownMessage, (channel, message) => {
+        log.verbose("wire.TypeMessage: ", message)
+        wdaClient.typeKey({value: [iosutil.asciiparser(message.key)]})
+      })
       .on(wire.BrowserOpenMessage, (channel, message) => {
         wdaClient.openUrl(message)
       })


### PR DESCRIPTION
The keyboard keys `(dpad_left, dpad_right, dpad_up, dpad_down, caps_lock and escape)` have been disabled in the file `lib/units/ios-device/plugins/util/iosutil.js` in order to prevent them from emitting wrong characters.
The `enter, tab and delete` functionality has been tested on iPhone 8 - iOS 16.0.