### PR TITLE
#688 Incorporate tap and keys with Apple TV buttons. Preventing Apple TV crashes.

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -151,8 +151,6 @@ module.exports = syrup.serial()
 
           // Apple TV keys 
 
-          log.info(value)
-
           switch (true) {
             case value === 'dpad_left':
               return this.handleRequest({

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -77,7 +77,11 @@ module.exports = syrup.serial()
                 this.sessionId = sessionResponse.sessionId
                 // #284 send info about battery to STF db
                 log.info(`sessionId: ${this.sessionId}`)
-                this.batteryIosEvent()
+
+                // Prevent Apple TV disconnection
+                if (options.deviceName !== 'Apple_TV') {
+                  this.batteryIosEvent()
+                }
 
                 return this.size()
               })
@@ -103,6 +107,7 @@ module.exports = syrup.serial()
         })
       },
       typeKey: function(params) {
+
         // collect several chars till the space and do mass actions...
         if (!params.value || !params.value[0]) {
           return
@@ -113,6 +118,8 @@ module.exports = syrup.serial()
         // register keyDown and keyUp for current char
         this.typeKeyActions.push({type: 'keyDown', value})
         this.typeKeyActions.push({type: 'keyUp', value})
+
+
 
         const handleRequest = () => {
           const requestParams = {
@@ -138,7 +145,64 @@ module.exports = syrup.serial()
             this.typeKeyTimerId = null
           }
 
-          return this.handleRequest(requestParams)
+          if (options.deviceName !== 'Apple_TV') {
+            return this.handleRequest(requestParams)
+          } 
+
+          // Apple TV keys 
+
+          log.info(value)
+
+          switch (true) {
+            case value === 'dpad_left':
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                body: {name: "left"},
+                json: true,
+              })
+              break;
+
+            case value === 'dpad_right':
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                body: {name: "right"},
+                json: true,
+              })
+              break;
+
+            case value === 'dpad_up':
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                body: {name: "up"},
+                json: true,
+              })
+              break;
+
+            case value === 'dpad_down':
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                body: {name: "down"},
+                json: true,
+              })
+              break;
+
+            case value === '\r':
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                body: {name: "select"},
+                json: true,
+              })
+              break;
+          
+            default:
+              break;
+          }
+
         }
 
         if (value === ' ') {
@@ -153,6 +217,7 @@ module.exports = syrup.serial()
           this.typeKeyTimerId = setTimeout(handleRequest, this.typeKeyDelay)
         }
       },
+
       tap: function(params) {
         this.tapStartAt = (new Date()).getTime()
         this.touchDownParams = params
@@ -161,7 +226,9 @@ module.exports = syrup.serial()
       homeBtn: function() {
         return this.handleRequest({
           method: 'POST',
-          uri: `${this.baseUrl}/wda/homescreen`
+          uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+          body: {name: "home"},
+          json: true
         })
       },
       swipe: function(params) {
@@ -183,6 +250,10 @@ module.exports = syrup.serial()
 
         this.isMove = true
 
+        if (options.deviceName === 'Apple_TV') {
+          return log.error('Swipe is not supported')
+        }
+
         return this.handleRequest({
           method: 'POST',
           uri: `${this.baseUrl}/session/${this.sessionId}/actions`,
@@ -196,6 +267,7 @@ module.exports = syrup.serial()
 
           x *= this.deviceSize.width
           y *= this.deviceSize.height
+
 
           if(((new Date()).getTime() - this.tapStartAt) <= 1000 || !this.tapStartAt) {
             const body = {
@@ -213,14 +285,71 @@ module.exports = syrup.serial()
               ],
             }
 
-            return this.handleRequest({
-              method: 'POST',
-              uri: `${this.baseUrl}/session/${this.sessionId}/actions`,
-              body,
-              json: true,
-            })
+            if (options.deviceName !== 'Apple_TV') {
+              log.info(options.deviceName)
+              return this.handleRequest({
+                method: 'POST',
+                uri: `${this.baseUrl}/session/${this.sessionId}/actions`,
+                body,
+                json: true,
+              })
+            // else if (deviceName === 'Watch_OS') {...}  
+            } else {
+              // Avoid crash, wait until width/height values are available
+              if (x && y) {
+                switch (true) {
+                  case x < 300:
+                    return this.handleRequest({
+                      method: 'POST',
+                      uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                      body: {name: "left"},
+                      json: true,
+                    })
+                  break;
+  
+                  case x > 1650:
+                    return this.handleRequest({
+                      method: 'POST',
+                      uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                      body: {name: "right"},
+                      json: true,
+                    })
+                  break;
+  
+                  case y > 850:
+                    return this.handleRequest({
+                      method: 'POST',
+                      uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                      body: {name: "down"},
+                      json: true,
+                    })
+                  break;
+  
+                  case y < 250:
+                    return this.handleRequest({
+                      method: 'POST',
+                      uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                      body: {name: "up"},
+                      json: true,
+                    })
+                  break;
+  
+                  default:
+                    return this.handleRequest({
+                      method: 'POST',
+                      uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+                      body: {name: "select"},
+                      json: true,
+                    })
+                    break; 
+                }
+              }
+            }
           }
           else {
+            if (options.deviceName === 'Apple_TV') {
+              return log.error('Holding tap is not supported')
+            }
             return this.handleRequest({
               method: 'POST',
               uri: `${this.baseUrl}/session/${this.sessionId}/wda/touchAndHold`,


### PR DESCRIPTION
The following modifications prevent different crashes disabling specific requests, since not all the endpoints are available in Apple TV devices. Depending on what direction the user taps, the device will press a button towards the tap direction.  