### PR TITLE
#465 Volume/Mute button fixes. Preventing media buttons crashes

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -1,5 +1,8 @@
 const fs = require('fs')
 const path = require('path')
+const logger = require('../../../../util/logger')
+
+var log = logger.createLogger('iosutil')
 
 let iosutil = {
   asciiparser: function(key) {
@@ -38,9 +41,9 @@ let iosutil = {
   pressButton: function(key) {
     switch (key) {
       case 'volume_up':
-        return this.pressButton('volumeup')
+        return this.pressButton('volumeUp')
       case 'volume_down':
-        return this.pressButton('volumedown')
+        return this.pressButton('volumeDown')
       case 'power':
         return this.pressPower()
       case 'camera':
@@ -52,9 +55,21 @@ let iosutil = {
       case 'mute': {
         let i
           for(i = 0; i < 25; i++) {
-            this.pressButton('volumedown')
+            this.pressButton('volumeDown')
           }
           return true }
+      case 'media_play_pause':
+        return log.error('Non-existent button in WDA') 
+      case 'media_stop':
+        return log.error('Non-existent button in WDA') 
+      case 'media_next':
+        return log.error('Non-existent button in WDA') 
+      case 'media_previous':
+        return log.error('Non-existent button in WDA') 
+      case 'media_fast_forward':
+        return log.error('Non-existent button in WDA') 
+      case 'media_rewind':
+        return log.error('Non-existent button in WDA') 
       default:
         return this.pressButton(key)
     }

--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -58,6 +58,8 @@ let iosutil = {
             this.pressButton('volumeDown')
           }
           return true }
+      
+      // Media button requests in case there's future WDA compatibility
       case 'media_play_pause':
         return log.error('Non-existent button in WDA') 
       case 'media_stop':


### PR DESCRIPTION
The following PR fixes typos inside `iosutil`, with this code Volume buttons and the Mute button will work. Since media buttons don't exist in WDA, the following code contains different `log.error()` to avoid crashes. 