### PR TITLE
#688 Conditionals Fix

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -291,7 +291,7 @@ module.exports = syrup.serial()
                 body,
                 json: true,
               })
-            // else if (deviceName === 'Watch_OS') {...}  
+            // else if (deviceType === 'Watch_OS') {...}  
             } else {
               // Avoid crash, wait until width/height values are available
               if (x && y) {
@@ -345,7 +345,7 @@ module.exports = syrup.serial()
             }
           }
           else {
-            if (options.deviceName === 'Apple_TV') {
+            if (options.deviceType === 'tvOS') {
               return log.error('Holding tap is not supported')
             }
             return this.handleRequest({

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -79,7 +79,7 @@ module.exports = syrup.serial()
                 log.info(`sessionId: ${this.sessionId}`)
 
                 // Prevent Apple TV disconnection
-                if (options.deviceName !== 'Apple_TV') {
+                if (options.deviceType !== 'tvOS') {
                   this.batteryIosEvent()
                 }
 
@@ -145,13 +145,11 @@ module.exports = syrup.serial()
             this.typeKeyTimerId = null
           }
 
-          if (options.deviceName !== 'Apple_TV') {
+          if (options.deviceType !== 'tvOS') {
             return this.handleRequest(requestParams)
           } 
 
           // Apple TV keys 
-
-          log.info(value)
 
           switch (true) {
             case value === 'dpad_left':
@@ -285,7 +283,7 @@ module.exports = syrup.serial()
               ],
             }
 
-            if (options.deviceName !== 'Apple_TV') {
+            if (options.deviceType !== 'tvOS') {
               log.info(options.deviceName)
               return this.handleRequest({
                 method: 'POST',

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -248,7 +248,7 @@ module.exports = syrup.serial()
 
         this.isMove = true
 
-        if (options.deviceName === 'Apple_TV') {
+        if (options.deviceType === 'tvOS') {
           return log.error('Swipe is not supported')
         }
 


### PR DESCRIPTION
In order to choose any name for the devices, it's necessary to change the following `if` statements.