### PR TITLE
#688 Dpad keys fix.

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -15,9 +15,13 @@ let iosutil = {
           return '\x08'
         // Disable keys (otherwise it sends the first character of key string on default case)
         case 'dpad_left':
+          return '\v'
         case 'dpad_up':
+          return '\0'
         case 'dpad_right':
+          return '\f'
         case 'dpad_down':
+          return '\x18'
         case 'caps_lock':
         case 'escape':
         case 'home':

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -161,7 +161,7 @@ module.exports = syrup.serial()
           // Apple TV keys 
 
           switch (true) {
-            case value === 'dpad_left':
+            case value === '\v':
               return this.handleRequest({
                 method: 'POST',
                 uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
@@ -170,7 +170,7 @@ module.exports = syrup.serial()
               })
               break;
 
-            case value === 'dpad_right':
+            case value === '\f':
               return this.handleRequest({
                 method: 'POST',
                 uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
@@ -179,7 +179,7 @@ module.exports = syrup.serial()
               })
               break;
 
-            case value === 'dpad_up':
+            case value === '\0':
               return this.handleRequest({
                 method: 'POST',
                 uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
@@ -188,7 +188,7 @@ module.exports = syrup.serial()
               })
               break;
 
-            case value === 'dpad_down':
+            case value === '\x18':
               return this.handleRequest({
                 method: 'POST',
                 uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,


### PR DESCRIPTION
The following modifications allow dpad keys to work in Apple TV devices. Since dpad keys were not used, their `return` value will still be blank strings. 