### PR TITLE
#404 Adjusting error message styles

### DIFF
--- a/res/app/control-panes/dashboard/install/install.pug
+++ b/res/app/control-panes/dashboard/install/install.pug
@@ -59,6 +59,6 @@
                 pre.manifest-text(ng-if='showManifest') {{ installation.manifest | json }}
 
       alert(type='danger', close='clear()', ng-if='installation.error')
-        strong(translate) Oops!
+        strong(style="display: block" translate) Oops!
         | &#x20;
-        span {{ installation.error | installError | translate }} ({{ installation.error }})
+        span(style="white-space: initial") {{ installation.error | installError | translate }} ({{ installation.error }})


### PR DESCRIPTION
The following modifications prevent the error message from being outside of its container.
