### PR TITLE
#464 Disabling Reset browser button for iOS devices

### DIFF
--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -52,6 +52,11 @@ module.exports = syrup.serial()
       .on(wire.BrowserOpenMessage, (channel, message) => {
         wdaClient.openUrl(message)
       })
+      // WDA cannot reset browser settings/cookies yet
+      
+      // .on(wire.BrowserClearMessage, (channel, message) => {
+      //   wdaClient.openUrl({url: 'https://www.google.com'})
+      // })
       .on(wire.RotateMessage, (channel, message) => {
         const rotation = iosutil.degreesToOrientation(message.rotation)
         wdaClient.rotation({orientation: rotation})

--- a/res/app/components/stf/control/control-service.js
+++ b/res/app/components/stf/control/control-service.js
@@ -265,7 +265,7 @@ module.exports = function ControlServiceFactory(
 
     this.clearBrowser = function(browser) {
       return sendTwoWay('browser.clear', {
-        browser: browser.id
+        browser: browser ? browser.id : null
       })
     }
 

--- a/res/app/control-panes/dashboard/navigation/navigation.pug
+++ b/res/app/control-panes/dashboard/navigation/navigation.pug
@@ -3,7 +3,8 @@
     stacked-icon(icon='fa-globe', color='color-blue')
     span(translate) Navigation
     span
-      button.btn.btn-xs.btn-danger-outline.pull-right(ng-click='clearSettings()',
+      button.btn.btn-xs.btn-danger-outline.pull-right(ng-disabled='device.ios'
+      ng-click='clearSettings()',
       uib-tooltip='{{ "Reset all browser settings" | translate }}')
         i.fa.fa-trash-o
         span(translate) Reset


### PR DESCRIPTION
The following code disables the reset browser button for iOS devices. It also prevents a console error when pressing the button with any iOS devices (inside `this.clearBrowser` ), which will be necessary if there's future implementation in WDA.

**Related thread:** https://github.com/facebookarchive/WebDriverAgent/issues/502