### PR TITLE
#728 Hiding crashing links for iOS

### DIFF
--- a/res/app/components/stf/device-context-menu/device-context-menu.pug
+++ b/res/app/components/stf/device-context-menu/device-context-menu.pug
@@ -1,7 +1,7 @@
 .dropdown.context-menu(id='context-menu-{{ $index }}')
   ul.dropdown-menu(role='menu')
     li
-      a.pointer(role='menuitem', ng-click='control.back(); $event.preventDefault()', ng-disabled='device.ios')
+      a.pointer(role='menuitem', ng-click='control.back(); $event.preventDefault()', ng-hide='device.ios')
         i.fa.fa-mail-reply.fa-fw
         span(translate) Back
     li
@@ -9,7 +9,7 @@
         i.fa.fa-home.fa-fw
         span(translate) Home
     li
-      a.pointer(role='menuitem', ng-click='control.appSwitch(); $event.preventDefault()', ng-disabled='device.ios')
+      a.pointer(role='menuitem', ng-click='control.appSwitch(); $event.preventDefault()', ng-hide='device.ios')
         i.fa.fa-square-o.fa-fw
         span(translate) Recents
     li.divider


### PR DESCRIPTION
Since the tags are <a> or links, the `disabled` has no effect on it. The following modification adjusts this by hiding the element through the attribute `display`