### PR TITLE
#739 Apple TV vertical tap fix

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -303,7 +303,7 @@ module.exports = syrup.serial()
             // else if (deviceType === 'Watch_OS') {...}  
             } else {
               // Avoid crash, wait until width/height values are available
-              if (x && y) {
+              if (x >= 0 && y >= 0) {
                 switch (true) {
                   case x < 300:
                     return this.handleRequest({


### PR DESCRIPTION
The following modification includes cases where `x` and  `y` coordinates values are 0. Fixing bug https://github.com/zebrunner/stf/issues/739