### PR TITLE
#749 Fixing home button for Apple TV

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -235,12 +235,22 @@ module.exports = syrup.serial()
         this.isMove = false
       },
       homeBtn: function() {
-        return this.handleRequest({
-          method: 'POST',
-          uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
-          body: {name: "home"},
-          json: true
-        })
+        if (options.deviceType !== 'tvOS') {
+          return this.handleRequest({
+            method: 'POST',
+            uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+            body: {name: "home"},
+            json: true
+          })
+        } else {
+          // #749: Fixing button action for AppleTV
+          return this.handleRequest({
+            method: 'POST',
+            uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
+            body: {name: "menu"},
+            json: true
+          })
+        }
       },
       swipe: function(params) {
         const scale = iosutil.swipe(this.orientation, params, this.deviceSize)


### PR DESCRIPTION
The following adjustment fixes the blue button for Apple TV devices. 