### PR TITLE
#177 Draft: Fixing error in RotationIosEvent

### DIFF
--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -60,12 +60,14 @@ module.exports = syrup.serial()
       .on(wire.RotateMessage, (channel, message) => {
         const rotation = iosutil.degreesToOrientation(message.rotation)
         wdaClient.rotation({orientation: rotation})
-          .then(() => {
+          .then((deviceSize) => {
             push.send([
               wireutil.global,
-              wireutil.envelope(new wire.RotationEvent(
+              wireutil.envelope(new wire.RotationIosEvent(
                 options.serial,
-                message.rotation
+                message.rotation,
+                deviceSize.height,
+                deviceSize.width
               ))
             ])
           })

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -289,6 +289,7 @@ module.exports = syrup.serial()
           x *= this.deviceSize.width
           y *= this.deviceSize.height
 
+          log.info('X: ' + x, 'Y: ' + y)
 
           if(((new Date()).getTime() - this.tapStartAt) <= 1000 || !this.tapStartAt) {
 
@@ -520,6 +521,10 @@ module.exports = syrup.serial()
           this.getOrientation()
 
           this.size()
+
+          let {height, width} = this.deviceSize
+
+          return {height, width}
         })
 
       },


### PR DESCRIPTION
The following code fixes an error in RotationIosEvent, now the device width/height are passed to the event when a rotation happens. The device coordinates still work incorrectly in Landscape mode