### PR TITLE
#754 Disabling crashing buttons (Apple TV)

### DIFF
--- a/res/app/control-panes/dashboard/clipboard/clipboard.pug
+++ b/res/app/control-panes/dashboard/clipboard/clipboard.pug
@@ -4,8 +4,8 @@
     span(translate) Clipboard
   .widget-content.padded
     .input-group.form-inline
-      textarea(rows='1', ng-model='control.clipboardContent', msd-elastic, text-focus-select,
+      textarea(rows='1', ng-model='control.clipboardContent', msd-elastic, text-focus-select, ng-disabled='device.platform === "tvOS"'
       tabindex='20').form-control.clipboard-textarea
       span.input-group-btn
-        button.btn.btn-primary-outline(ng-click='control.getClipboardContent()', uib-tooltip='{{ "Get clipboard contents" | translate }}')
+        button.btn.btn-primary-outline(ng-click='control.getClipboardContent()', uib-tooltip='{{ "Get clipboard contents" | translate }}', ng-disabled='device.platform === "tvOS"')
           i.fa.fa-refresh

--- a/res/app/control-panes/device-control/device-control.pug
+++ b/res/app/control-panes/device-control/device-control.pug
@@ -5,11 +5,11 @@
         .stf-vnc-control-header.as-cell
           .stf-vnc-right-buttons.pull-right
             .btn-group
-              label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("portrait")',
+              label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("portrait")', ng-hide='device.platform === "tvOS"',
               ng-model='currentRotation', uib-btn-radio='"portrait"',
               uib-tooltip='{{ "Portrait" | translate }} ({{ "Current rotation:" | translate }} {{ device.display.rotation }}°)', tooltip-placement='bottom').pointer
                 i.fa.fa-mobile
-              label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("landscape")',
+              label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("landscape")', ng-hide='device.platform === "tvOS"',
                 ng-model='currentRotation', uib-btn-radio='"landscape"',
               uib-tooltip='{{ "Landscape" | translate }} ({{ "Current rotation:" | translate }} {{ device.display.rotation }}°)', tooltip-placement='bottom').pointer
                 i.fa.fa-mobile.fa-rotate-90


### PR DESCRIPTION
The following PR disables crashing buttons in Apple TV devices.