### PR TITLE
#463 Adding Switch Charset function for WDA client

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -62,7 +62,9 @@ let iosutil = {
             this.pressButton('volumeDown')
           }
           return true }
-      
+      case 'switch_charset': {
+        return this.switchCharset()
+      }
       // Media button requests in case there's future WDA compatibility
       case 'media_play_pause':
         return log.error('Non-existent button in WDA') 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -30,6 +30,7 @@ module.exports = syrup.serial()
       typeKeyActions: [],
       typeKeyTimerId: null,
       typeKeyDelay: 250,
+      upperCase: false,
 
       startSession: function() {
         log.info('verifying wda session status...')
@@ -126,13 +127,16 @@ module.exports = syrup.serial()
           return
         }
 
-        const [value] = params.value
+        let [value] = params.value
 
         // register keyDown and keyUp for current char
+
+        if (this.upperCase) {
+          value = value.toUpperCase()
+        }
+
         this.typeKeyActions.push({type: 'keyDown', value})
         this.typeKeyActions.push({type: 'keyUp', value})
-
-
 
         const handleRequest = () => {
           const requestParams = {
@@ -569,6 +573,11 @@ module.exports = syrup.serial()
           },
           json: true
         })
+      },
+      switchCharset: function() {      
+        this.upperCase = !this.upperCase
+
+        log.info(this.upperCase)
       },
       appActivate: function(params) {
         return this.handleRequest({

--- a/res/app/control-panes/advanced/input/input.pug
+++ b/res/app/control-panes/advanced/input/input.pug
@@ -10,7 +10,7 @@
           i.fa.fa-power-off
         button(uib-tooltip='{{ "Camera" | translate }}', ng-click='press("camera")').btn.btn-primary.btn-xs
           i.fa.fa-camera
-        button(uib-tooltip='{{ "Switch Charset" | translate }}', ng-click='press("switch_charset")' ng-disabled='device.ios').btn.btn-primary.btn-info.btn-xs
+        button(uib-tooltip='{{ "Switch Charset" | translate }}', ng-click='press("switch_charset")' ng-disabled='device.platform === "tvOS"').btn.btn-primary.btn-info.btn-xs
           i.fa  Aa
         button(uib-tooltip='{{ "Search" | translate }}', ng-click='press("search")').btn.btn-primary.btn-xs
           i.fa.fa-search


### PR DESCRIPTION
The following code implements a `switchCharset()` method in WdaClient.js, which is triggered whenever the switch charset button is clicked. The method changes `this.upperCase` variable as false/true, depending on its value `typeKey()` method will send uppercased keys.

It also disables the button for AppleTV devices.