### PR TITLE
#762 16.1 devices locking fix

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -627,6 +627,10 @@ module.exports = syrup.serial()
               return resolve(response)
             })
             .catch(err => {
+              // #762: Skip lock error message 
+              if (err.error.value.message.includes('Timed out while waiting until the screen gets locked')) {
+                return
+              }
               recoverDevice()
               // #409: capture wda/appium crash asap and exit with status 1 from stf
               //notifier.setDeviceTemporaryUnavialable(err)
@@ -636,7 +640,6 @@ module.exports = syrup.serial()
         })
       },
     }
-
 
     /*
      * WDA MJPEG connection is stable enough to be track status wda server itself.


### PR DESCRIPTION
The following code skips the error lock crash, so the device keeps working correctly