### PR TITLE
#765 Skip iOS rotation crash

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -293,7 +293,6 @@ module.exports = syrup.serial()
           x *= this.deviceSize.width
           y *= this.deviceSize.height
 
-
           if(((new Date()).getTime() - this.tapStartAt) <= 1000 || !this.tapStartAt) {
 
             const body = {
@@ -630,6 +629,9 @@ module.exports = syrup.serial()
               // #762: Skip lock error message 
               if (err.error.value.message.includes('Timed out while waiting until the screen gets locked')) {
                 return
+              }
+              if (err.error.value.message.includes('Unable To Rotate Device')) {
+                return log.info('The current application does not support rotation')
               }
               recoverDevice()
               // #409: capture wda/appium crash asap and exit with status 1 from stf


### PR DESCRIPTION
The following code prevents a crash when trying to rotate the device in an App. where rotation is not enabled, preventing the following error: `Unable To Rotate Device`