### PR TITLE
#770 Fixing Landscape when closing device (reset to Portrait mode)

### DIFF
--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -106,8 +106,14 @@ module.exports = syrup.serial()
             } 
 
             // #770: Reset rotation to Portrait when closing device
-            WdaClient.rotation({orientation: 'PORTRAIT'})
-            Promise.delay(3000).then(() => stoppingSession())
+
+            const rotationPromise = new Promise((resolve, reject) => {
+              // Ensure that rotation is done, then stop session
+              WdaClient.rotation({orientation: 'PORTRAIT'})
+              resolve()
+            })
+
+            rotationPromise.then(() => stoppingSession())
         })
         ws.on('error', function() {
           // @TODO handle error event

--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -92,7 +92,7 @@ module.exports = syrup.serial()
 
         ws.on('close', function() {
           // @TODO handle close event
-
+          // stream.socket.onclose()
             const orientation = WdaClient.orientation
 
             const stoppingSession = () => {
@@ -105,8 +105,9 @@ module.exports = syrup.serial()
               return stoppingSession()
             } 
 
+            // #770: Reset rotation to Portrait when closing device
             WdaClient.rotation({orientation: 'PORTRAIT'})
-            Promise.delay(3000).then(stoppingSession)
+            Promise.delay(3000).then(() => stoppingSession())
         })
         ws.on('error', function() {
           // @TODO handle error event

--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -92,10 +92,21 @@ module.exports = syrup.serial()
 
         ws.on('close', function() {
           // @TODO handle close event
-          //stream.socket.onclose()
-          WdaClient.stopSession()
-          isConnectionAlive = false
-          log.important('ws on close event')
+
+            const orientation = WdaClient.orientation
+
+            const stoppingSession = () => {
+              WdaClient.stopSession()
+              isConnectionAlive = false
+              log.important('ws on close event')
+            }
+            
+            if (orientation === 'PORTRAIT') {
+              return stoppingSession()
+            } 
+
+            WdaClient.rotation({orientation: 'PORTRAIT'})
+            Promise.delay(3000).then(stoppingSession)
         })
         ws.on('error', function() {
           // @TODO handle error event

--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -42,6 +42,18 @@ let iosutil = {
         return 'UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT'
     }
   },
+  orientationToDegrees: function(orientation) {
+    switch (orientation) {
+      case 'PORTRAIT':
+        return 0
+      case 'LANDSCAPE':
+        return 90
+      case 'UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN':
+        return 180
+      case 'UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT':
+        return 270
+    }
+  },
   pressButton: function(key) {
     switch (key) {
       case 'volume_up':

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -113,10 +113,11 @@ module.exports = syrup.serial()
           return Promise.resolve()
         }
 
-        this.handleRequest({
+        return this.handleRequest({
           method: 'DELETE',
           uri: `${this.baseUrl}/session/${currentSessionId}`
         })
+        
       },
       typeKey: function(params) {
 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -533,8 +533,17 @@ module.exports = syrup.serial()
           this.getOrientation()
 
           this.size()
-        })
 
+          const rotationDegrees = iosutil.orientationToDegrees(this.orientation)
+
+          push.send([
+            wireutil.global,
+            wireutil.envelope(new wire.RotationEvent(
+              options.serial,
+              rotationDegrees
+            ))
+          ])
+        })
       },
       batteryIosEvent: function() {
         return this.handleRequest({

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -646,13 +646,23 @@ module.exports = syrup.serial()
               return resolve(response)
             })
             .catch(err => {
+              let errMes = err.error.value.message
+
               // #762: Skip lock error message 
-              if (err.error.value.message.includes('Timed out while waiting until the screen gets locked')) {
+              if (errMes.includes('Timed out while waiting until the screen gets locked')) {
                 return
               }
-              if (err.error.value.message.includes('Unable To Rotate Device')) {
+
+              // #765: Skip rotation error message 
+              if (errMes.includes('Unable To Rotate Device')) {
                 return log.info('The current application does not support rotation')
               }
+
+              // #770 Skip session crash, immediately restart after Portrait mode reset
+              if (errMes.includes('Session does not exist')) {
+                return this.startSession()
+              }
+              
               recoverDevice()
               // #409: capture wda/appium crash asap and exit with status 1 from stf
               //notifier.setDeviceTemporaryUnavialable(err)


### PR DESCRIPTION
The following PR includes:

- A new request to `/rotation` endpoint before closing session (reset to Portrait)
- A new `orientationToDegrees` method in iosutil
- A `return` statement to `stopSession` method
- Using `RotationEvent` to correctly update the new rotation values 
- Improving error message handling