### PR TITLE
#770 Adding exception for tvOS

### DIFF
--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -108,7 +108,7 @@ module.exports = syrup.serial()
               log.important('ws on close event')
             }
             
-            if (orientation === 'PORTRAIT') {
+            if (options.deviceType === 'tvOS' || orientation === 'PORTRAIT') {
               return stoppingSession()
             } 
 


### PR DESCRIPTION
When starting WDA, rotation will be skipped for AppleTV devices.