### PR TITLE
#410 Adding 'Preparing' state to iOS devices on WDA startup

### DIFF
--- a/lib/units/ios-device/plugins/solo.js
+++ b/lib/units/ios-device/plugins/solo.js
@@ -41,6 +41,15 @@ module.exports = syrup.serial()
                     , channel
                   ))
                 ])
+
+                // #410: Use status 6 (preparing) on WDA startup
+                push.send([
+                  wireutil.global,
+                  wireutil.envelope(new wire.DeviceStatusMessage(
+                    options.serial,
+                    6
+                  ))
+                ])
               })
           })
           .catch(err => {

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -17,7 +17,7 @@ module.exports = syrup.serial()
   .define((options, notifier, push) => {
     const log = logger.createLogger('wdaClient')
     log.info("WdaClient.js initializing...")
-
+    
     const socket = new net.Socket()
     const WdaClient = {
       baseUrl: iosutil.getUri(options.wdaHost, options.wdaPort),
@@ -56,6 +56,9 @@ module.exports = syrup.serial()
 
               // handles case of existing session
               if (statusResponse.sessionId) {
+
+                this.setStatus(3)
+
                 this.sessionId = statusResponse.sessionId
                 log.info(`reusing existing wda session: ${this.sessionId}`)
                 
@@ -94,6 +97,8 @@ module.exports = syrup.serial()
                     this.batteryIosEvent()
                   }
 
+                  this.setStatus(3)
+
                   return this.size()
                 })
                 .catch((err) => {
@@ -118,6 +123,15 @@ module.exports = syrup.serial()
           uri: `${this.baseUrl}/session/${currentSessionId}`
         })
         
+      },
+      setStatus: function(status) {
+        push.send([
+          wireutil.global,
+          wireutil.envelope(new wire.DeviceStatusMessage(
+            options.serial,
+            status
+          ))
+        ])
       },
       typeKey: function(params) {
 

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -415,6 +415,7 @@ enum DeviceStatus {
   ONLINE = 3;
   CONNECTING = 4;
   AUTHORIZING = 5;
+  PREPARING = 6;
 }
 
 message DeviceStatusMessage {

--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -46,11 +46,22 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
   }
 
   function enhanceDevice(device) {
-    device.enhancedName = device.marketName || device.name || device.model || device.serial
-      || 'Unknown'
+    device.enhancedName = device.marketName || device.name || device.model || device.serial || 'Unknown'
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.platform || device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.platform || device.image || '_default.jpg')
+    if (device.ios && device.status === 6 && device.state !== 'present') {
+      device.enhancedStateAction = $filter('statusNameAction')('preparing')
+      device.enhancedStatePassive = $filter('statusNamePassive')('preparing')
+      return
+    } 
+    if (device.ios && device.status === 6 && device.state === 'present') {
+      device.status = 3
+      device.state = 'available'
+      device.enhancedStateAction = $filter('statusNameAction')('available')
+      device.enhancedStatePassive = $filter('statusNamePassive')('available')
+      return
+    } 
     device.enhancedStateAction = $filter('statusNameAction')(device.state)
     device.enhancedStatePassive = $filter('statusNamePassive')(device.state)
   }

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -694,7 +694,13 @@ function DeviceStatusCell(options) {
         a.removeAttribute('href')
       }
 
+      if (device.status === 6) {
+        a.className = 'btn btn-xs device-status btn-success-outline'
+      }
+
       t.nodeValue = options.value(device)
+
+
 
       return td
     }

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -96,6 +96,11 @@ module.exports = function DeviceListIconsDirective(
           a.removeAttribute('href')
           li.classList.add('device-is-busy')
         }
+
+        if (device.status === 6) {
+          button.className = ('btn btn-xs device-status btn-success-outline')
+        } 
+
         return li
       }
     }


### PR DESCRIPTION
The following PR includes:

- A new device status code (6), used when starting WDA.
- A `setStatus` method in WdaClient to change the device status dynamically.
- When the session starts, the status is set to 3.
- In the `enhanceDevice` function, the UI will be change to 'Preparing' state to 'Available' state dynamically.
- 'Preparing' state reuses green font for the text (same as Android)