### PR TITLE
#274 Identifying same and different frames to optimize stream

### DIFF
--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -6,6 +6,7 @@ const Promise = require('bluebird')
 const request = require('request')
 const wireutil = require('../../../../wire/util')
 const wire = require('../../../../wire')
+const { Transform } = require('stream')
 
 const logger = require('../../../../util/logger')
 const iosutil = require('../util/iosutil')
@@ -64,7 +65,30 @@ module.exports = syrup.serial()
             .then(() => handleSocketError({message: 'Connection failed to WDA MJPEG port'}, 'Consumer error'))
             .catch(result => {
               if(result) {
-                result.response.pipe(consumer).pipe(stream)
+
+                let previousFrame = null
+                
+                class FrameFilter extends Transform {
+                  constructor(options) {
+                    super(options)
+                  }
+                
+                  _transform(chunk, encoding, callback) {
+                    const currentFrame = chunk.toString('base64');
+
+                    if (currentFrame !== previousFrame) {
+                      this.push(chunk)
+                      previousFrame = currentFrame
+                    }
+
+                    callback()
+                  }
+                }
+                
+                const frameFilter = new FrameFilter();
+                
+                result.response.pipe(frameFilter).pipe(consumer).pipe(stream);
+                
                 //[VD] We can't launch homeBtn otherwise opening in STF corrupt test automation run. Also no sense to execute connect
                 WdaClient.startSession()
                 //WdaClient.homeBtn() //no existing session detected so we can press home button to wake up device automatically


### PR DESCRIPTION
The following code identifies old and new frames, if the frame is a new one, the frame is pushed to the pipeline and then processed in the stream.





