### PR TITLE
#801 Reset device to Portrait mode coordinates when pressing home button

### DIFF
--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -21,7 +21,11 @@ module.exports = syrup.serial()
   Wda.connect = () => {
     sub.on('message', wirerouter()
       .on(wire.KeyPressMessage, (channel, message) => {
-        iosutil.pressButton.call(wdaClient, message.key)
+        if (wdaClient.orientation === 'LANDSCAPE' && message.key === 'home') {
+          wdaClient.rotation({orientation: 'PORTRAIT'}).then(() => {
+            iosutil.pressButton.call(wdaClient, message.key)
+          })
+        }
       })
       .on(wire.StoreOpenMessage, (channel, message) => {
         wdaClient.appActivate('com.apple.AppStore')

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -258,6 +258,9 @@ module.exports = syrup.serial()
             uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
             body: {name: "home"},
             json: true
+          }).then(() => {
+            // #801 Reset coordinates to Portrait mode after pressing home button
+            return this.rotation({orientation: 'PORTRAIT'})
           })
         } else {
           // #749: Fixing button action for AppleTV


### PR DESCRIPTION
The following PR resets the device to Portrait mode before sending the Home button request, as well as setting the device coordinates to Portrait mode