### PR TITLE
#469 Enabling 'Find' button for iOS

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -66,6 +66,8 @@ let iosutil = {
         return this.appActivate('com.apple.camera')
       case 'search':
         return this.appActivate('com.apple.mobilesafari')
+      case 'finder':
+        return this.appActivate('com.apple.findmy')
       case 'home':
         return this.homeBtn()
       case 'mute': {

--- a/res/app/control-panes/info/info-controller.js
+++ b/res/app/control-panes/info/info-controller.js
@@ -5,6 +5,10 @@ module.exports = function InfoCtrl($scope, LightboxImageService) {
     LightboxImageService.open(title, enhancedPhoto800)
   }
 
+  $scope.press = function(key) {
+    $scope.control.keyPress(key)
+  }
+
   $scope.finder = function() { 
     $scope.control.identify()
   }

--- a/res/app/control-panes/info/info.pug
+++ b/res/app/control-panes/info/info.pug
@@ -7,7 +7,7 @@
         stacked-icon(icon='fa-location-arrow', color='color-pink')
         span(translate) Physical Device
         .pull-right
-          button(ng-click='finder()', ng-disabled='device.ios').btn.btn-xs.btn-primary-outline
+          button(ng-click='device.ios ? press("finder") : finder()').btn.btn-xs.btn-primary-outline
             i.fa.fa-info
             span(translate) Find Device
 


### PR DESCRIPTION
The following PR enables Find device button for ios and uses the Finder app. bundleId correctly