### PR TITLE
[Draft] #818 Set api maxlisteners to 100

### DIFF
--- a/lib/units/api/index.js
+++ b/lib/units/api/index.js
@@ -24,6 +24,7 @@ module.exports = function(options) {
   var app = express()
   var server = http.createServer(app)
   var channelRouter = new events.EventEmitter()
+  channelRouter.setMaxListeners(100)
 
   var push = zmqutil.socket('push')
   Promise.map(options.endpoints.push, function(endpoint) {


### PR DESCRIPTION
The following PR adjusts the amount of listeners in `channelRouter`