### PR TITLE
#827 Catching adb client

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -179,8 +179,8 @@ module.exports = function(options) {
       })
 
       register.catch(function(err) {
-        log.error('Register error', err)
-        process.exit(1)
+        log.fatal('Register promise error', err)
+        lifecycle.fatal()
       })
 
       // Spawn a device worker
@@ -434,8 +434,8 @@ module.exports = function(options) {
     lifecycle.share('Tracker', tracker)
   })
   .catch(function(err) {
-    log.error('trackDevices error', err)
-    process.exit(1)
+    log.fatal('Adb client error', err)
+    lifecycle.fatal()
   })
 
   lifecycle.observe(function() {

--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -114,7 +114,8 @@ module.exports = function(options) {
   })
 
   // Track and manage devices
-  client.trackDevices().then(function(tracker) {
+  client.trackDevices()
+  .then(function(tracker) {
     // This can happen when ADB doesn't have a good connection to
     // the device
     function isWeirdUnusableDevice(device) {
@@ -431,6 +432,10 @@ module.exports = function(options) {
       .handler())
 
     lifecycle.share('Tracker', tracker)
+  })
+  .catch(function(err) {
+    log.error('trackDevices error', err)
+    process.exit(1)
   })
 
   lifecycle.observe(function() {


### PR DESCRIPTION
The following PR adds a `catch` to the adb client `trackDevices` promise.