### PR TITLE
#816 fixes for four issues

### DIFF
--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -46,7 +46,7 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
   }
 
   function enhanceDevice(device) {
-    device.enhancedName = device.marketName || device.name || device.model || device.serial || 'Unknown'
+    device.enhancedName = device.model || device.product  || device.marketName || device.serial || 'Unknown'
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.platform || device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.platform || device.image || '_default.jpg')

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -392,7 +392,7 @@ function compareRespectCase(a, b) {
     return 0
   }
   else {
-    return a < b ? -1 : 1
+    return a.localeCompare(b)
   }
 }
 

--- a/res/app/device-list/details/device-list-details-directive.js
+++ b/res/app/device-list/details/device-list-details-directive.js
@@ -39,7 +39,10 @@ module.exports = function DeviceListDetailsDirective(
           LogcatService.deviceEntries[device.serial].allowClean = true
         }
         $rootScope.LogcatService = LogcatService
-        return GroupService.kick(device, force).catch(function(e) {
+        return GroupService.kick(device, force).then((response) => {
+          storeDevices(device)
+          storeRows()
+        }).catch(function(e) {
           alert($filter('translate')(gettext('Device cannot get kicked from the group')))
           throw new Error(e)
         })
@@ -48,6 +51,8 @@ module.exports = function DeviceListDetailsDirective(
       function inviteDevice(device) {
         $rootScope.usedDevices.push(device.serial)
         return GroupService.invite(device).then(function() {
+          storeDevices(device)
+          storeRows()
           scope.$digest()
         })
       }
@@ -65,17 +70,15 @@ module.exports = function DeviceListDetailsDirective(
           if (e.shiftKey && device.state === 'available') {
             StandaloneService.open(device)
             e.preventDefault()
+            storeDevices(device)
+            storeRows()
           }
 
           if ($rootScope.adminMode && device.state === 'busy') {
-            storeDevices(device)
-            storeRows()
             kickDevice(device, true)
             e.preventDefault()
           }
-          else if (device.using) {
-            storeDevices(device)
-            storeRows()
+          else if (device.using || e.target.className.includes('state-using')) {
             kickDevice(device)
             e.preventDefault()
           }

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -209,12 +209,6 @@ module.exports = function DeviceListIconsDirective(
         , desc: 'asc'
         }
 
-        var fixedMatch = findInSorting(scope.sort.fixed)
-        if (fixedMatch) {
-          fixedMatch.order = swap[fixedMatch.order]
-          return
-        }
-
         var userMatch = findInSorting(scope.sort.user)
         if (userMatch) {
           userMatch.order = swap[userMatch.order]
@@ -369,6 +363,12 @@ module.exports = function DeviceListIconsDirective(
           // Find the first difference
           for (var i = 0, l = activeSorting.length; i < l; ++i) {
             var sort = activeSorting[i]
+
+            if (sort.name === 'default') {
+              diff = 0
+              break
+            }
+
             diff = scope.columnDefinitions[sort.name].compare(deviceA, deviceB)
             if (diff !== 0) {
               diff *= mapping[sort.order]


### PR DESCRIPTION
The following PR does the following:

- Sorts all devices in `Devices` page correctly
- Replaces `enhancedName` with `device.name | device.product`
- Compares model names with `localCompare`
- Instantly assigns device as busy on click
 