### PR TITLE
#556 Reusing existing size values from RethinkDB

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1531,10 +1531,14 @@ dbapi.sizeIosDevice = function(message) {
     return db.run(r.table('devices').get(message.id).update({
       display: {
         height: message.height,
-        width: message.width
+        width: message.width,
+        scale: message.scale
       }
     }
   ))
+}
+dbapi.getDeviceSize = function(serial) {
+  return db.run(r.table('devices').get(serial).pluck('display')) 
 }
 dbapi.checkIosDeviceConnected = function(data) {
   return db.run(r.table('devices').get(data.id))

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -247,6 +247,18 @@ function getDeviceBySerial(req, res) {
     })
 }
 
+function getDeviceSize (req, res) {
+  var serial = req.swagger.params.serial.value
+  dbapi.getDeviceSize(serial)
+  .then(response => {
+    return res.status(200).json(response.display)
+  })
+  .catch(function(err) {
+    apiutil.internalError(res, 'Failed to get device size', err.stack)
+    return apiutil.respond(res, 404, 'Not Found (device)')
+  })
+}
+
 function getDeviceGroups(req, res) {
   const serial = req.swagger.params.serial.value
   const fields = req.swagger.params.fields.value
@@ -563,6 +575,7 @@ module.exports = {
   getDevices: getDevices
 , putDeviceBySerial: putDeviceBySerial
 , getDeviceBySerial: getDeviceBySerial
+, getDeviceSize: getDeviceSize
 , getDeviceGroups: getDeviceGroups
 , getDeviceBookings: getDeviceBookings
 , addOriginGroupDevice: addOriginGroupDevice

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -1916,6 +1916,32 @@ paths:
             $ref: "#/definitions/UnexpectedErrorResponse"
       security:
         - accessTokenAuth: [ ]
+  /devices/{serial}/size:
+    x-swagger-router-controller: devices
+    get:
+      summary: Gets the size of a device
+      description: Gets the size of a device
+      operationId: getDeviceSize
+      tags:
+        - user
+      parameters:
+        - name: serial
+          in: path
+          description: Device identifier (serial)
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Device size information
+          schema:
+            $ref: "#/definitions/SizeResponse"
+        default:
+          description: >
+            Unexpected Error:
+              * 404: Not Found => unknown device
+              * 500: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /devices/groups/{id}:
     x-swagger-router-controller: devices
     put:
@@ -2331,6 +2357,15 @@ definitions:
         type: array
         items:
           type: object
+  SizeResponse: 
+    required:
+      - height
+      - width
+    properties:
+      height:
+        type: integer
+      width:
+        type: integer
   DeviceResponse:
     required:
       - success

--- a/lib/units/api/swagger/api_v1_generated.json
+++ b/lib/units/api/swagger/api_v1_generated.json
@@ -400,6 +400,39 @@
         ]
       }
     },
+    "/devices/{serial}/size": {
+      "get": {
+        "summary": "Gets the size of a device",
+        "description": "Gets the size of a device",
+        "operationId": "getDeviceSize",
+        "tags": [
+          "user"
+        ],
+        "parameters": [
+          {
+            "name": "serial",
+            "in": "path",
+            "description": "Device identifier (serial)",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Device size information",
+            "schema": {
+              "$ref": "#/definitions/SizeResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/swagger.json": {}
   },
   "definitions": {
@@ -486,6 +519,17 @@
       "properties": {
         "message": {
           "type": "string"
+        }
+      }
+    },
+    "SizeResponse": {
+      "required": ["height", "width"],
+      "properties": {
+        "height": {
+          "type": "integer"
+        },
+        "width": {
+          "type": "integer"
         }
       }
     }

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -453,41 +453,60 @@ module.exports = syrup.serial()
       size: function() {
         log.info('getting device window size...')
 
+        // #556: Get device size from RethinkDB
         return this.handleRequest({
           method: 'GET',
-          uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
+          uri: `${options.storageUrl}api/v1/devices/${options.serial}/size`,
         })
           .then((windowSizeResponse) => {
-            try {
-              this.deviceSize = JSON.parse(windowSizeResponse).value
-              let {height, width} = this.deviceSize
+              let {height, width, scale} = JSON.parse(windowSizeResponse)
 
-              return this.handleRequest({
-                method: 'GET',
-                uri: `${this.baseUrl}/session/${this.sessionId}/wda/screen`,
-              })
-                .then((wdaScreenResponse) => {
-                  const {scale} = JSON.parse(wdaScreenResponse).value
+              // First device session 
+              if (!height || !width || !scale) {
+                return this.handleRequest({
+                  method: 'GET',
+                  uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
+                }).then((firstSessionSize) => { 
+                  this.deviceSize = JSON.parse(firstSessionSize).value
+                  let {height, width} = this.deviceSize
 
-                  height *= scale
-                  width *= scale
+                  return this.handleRequest({
+                    method: 'GET',
+                    uri: `${this.baseUrl}/session/${this.sessionId}/wda/screen`,
+                  })
+                    .then((wdaScreenResponse) => {
+                      const {scale} = JSON.parse(wdaScreenResponse).value
 
-                  push.send([
-                      wireutil.global,
-                      wireutil.envelope(new wire.SizeIosDevice(
-                        options.serial,
-                        height,
-                        width,
-                      ))
-                    ])
+                      log.info(scale)
 
-                  return this.deviceSize
+                      height *= scale
+                      width *= scale
+
+                      log.info('Storing device size/scale')
+
+                      push.send([
+                          wireutil.global,
+                          wireutil.envelope(new wire.SizeIosDevice(
+                            options.serial,
+                            height,
+                            width,
+                            scale
+                          ))
+                        ])
+
+                      return this.deviceSize
+                    })
                 })
-            }
-            catch (e) {
-              throw new Error('Failed to parse json window size response object')
-            }
-          })
+              } else {
+                log.info('Reusing device size/scale')
+                if (this.orientation === 'PORTRAIT') {
+                  this.deviceSize = { height: height /= scale, width: width /= scale }  
+                } else if (this.orientation === 'LANDSCAPE') {
+                  this.deviceSize = { height: width /= scale, width: height /= scale }
+                }
+                return this.deviceSize
+              }
+            })
       },
       setVersion: function(currentSession) {
         log.info('Setting device version: ' + currentSession.value.capabilities.sdkVersion)
@@ -668,7 +687,7 @@ module.exports = syrup.serial()
               return resolve(response)
             })
             .catch(err => {
-              let errMes = err.error.value.message
+              let errMes = err.error.value.message ? err.error.value.message : ''
 
               // #762: Skip lock error message 
               if (errMes.includes('Timed out while waiting until the screen gets locked')) {

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -926,6 +926,7 @@ message SizeIosDevice{
   required string id = 1;
   required double height = 2;
   required double width = 3;
+  required int32 scale = 4;
 }
 message DashboardOpenMessage {
 }


### PR DESCRIPTION
The following PR implements: 

- A new `scale` property in the device `display` object.
- A new endpoint in `/api/v1` to get the device's size/scale values.
- Reusing RethinkDB data to skip WDA calls.  