### PR TITLE
#847 Fix for displaying Unhealthy status correctly in Android

### DIFF
--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -62,12 +62,12 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
       device.enhancedStatePassive = $filter('statusNamePassive')('available')
       return
     } 
-    if (device.ios && device.status === 1) {
+    if (device.status === 1) {
       device.enhancedStateAction = $filter('statusNameAction')('offline')
       device.enhancedStatePassive = $filter('statusNamePassive')('offline')
       return
     } 
-    if (device.ios && device.status === 7) {
+    if (device.status === 7) {
       device.enhancedStateAction = $filter('statusNameAction')('unhealthy')
       device.enhancedStatePassive = $filter('statusNamePassive')('unhealthy')
       return


### PR DESCRIPTION
The following PR allows to set `Unhealthy` and `Offline` status correctly if needed in Android devices.