### PR TITLE
#864 Skip error message when unlocking device

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -689,8 +689,8 @@ module.exports = syrup.serial()
             .catch(err => {
               let errMes = err.error.value.message ? err.error.value.message : ''
 
-              // #762: Skip lock error message 
-              if (errMes.includes('Timed out while waiting until the screen gets locked')) {
+              // #762 & #864: Skip lock/unlock error messages 
+              if (errMes.includes('Timed out while waiting until the screen gets locked') || errMes.includes('unlocked')) {
                 return
               }
 


### PR DESCRIPTION
The following PR skips an error message when unlocking iOS 17+ devices, preventing crash.