### PR TITLE
#875 Wait for rotation event to finish

### DIFF
--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -25,6 +25,9 @@ module.exports = syrup.serial()
           wdaClient.rotation({orientation: 'PORTRAIT'}).then(() => {
             iosutil.pressButton.call(wdaClient, message.key)
           })
+          .catch(err => {
+            log.error('Failed to rotate device to : ', rotation, err)
+          })
         }
         // On portait mode -> home button directly
         iosutil.pressButton.call(wdaClient, message.key)
@@ -64,6 +67,12 @@ module.exports = syrup.serial()
       //   wdaClient.openUrl({url: 'https://www.google.com'})
       // })
       .on(wire.RotateMessage, (channel, message) => {
+
+        // #875 Ignore rotation operation while device is rotating
+        if (wdaClient.isRotating) {
+          return
+        }
+
         const rotation = iosutil.degreesToOrientation(message.rotation)
         wdaClient.rotation({orientation: rotation})
           .then(() => {

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -31,6 +31,7 @@ module.exports = syrup.serial()
       typeKeyDelay: 250,
       upperCase: false,
       isSwiping: false,
+      isRotating: false,
 
       startSession: function() {
         log.info('verifying wda session status...')
@@ -566,6 +567,8 @@ module.exports = syrup.serial()
       rotation: function(params) {
         this.orientation = params.orientation
 
+        this.isRotating = true
+
         return this.handleRequest({
           method: 'POST',
           uri: `${this.baseUrl}/session/${this.sessionId}/orientation`,
@@ -585,6 +588,8 @@ module.exports = syrup.serial()
               rotationDegrees
             ))
           ])
+
+          this.isRotating = false
         })
       },
       batteryIosEvent: function() {


### PR DESCRIPTION
In this PR I added an error catch for `home` button when rotating and a `wdaClient` property to detect when the device is already rotating.