### PR TITLE
#451 Hide model column by default

### DIFF
--- a/res/app/device-list/device-list-controller.js
+++ b/res/app/device-list/device-list-controller.js
@@ -25,7 +25,7 @@ module.exports = function DeviceListCtrl(
     }
   , {
       name: 'model'
-    , selected: true
+    , selected: false
     }
   , {
       name: 'name'


### PR DESCRIPTION
The following PR hides the model name column by default.