### PR TITLE
#883 Return '0' values when empty DB size, improve size method

### DIFF
--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -254,8 +254,8 @@ function getDeviceSize (req, res) {
     return res.status(200).json(response.display)
   })
   .catch(function(err) {
-    apiutil.internalError(res, 'Failed to get device size', err.stack)
-    return apiutil.respond(res, 404, 'Not Found (device)')
+    log.info('Failed to get device size: ', err.stack)
+    return res.status(200).json({height: 0, width: 0, scale: 0})
   })
 }
 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -454,51 +454,54 @@ module.exports = syrup.serial()
       size: function() {
         log.info('getting device window size...')
 
+        const firstSession = () => this.handleRequest({
+          method: 'GET',
+          uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
+        }).then((firstSessionSize) => { 
+          this.deviceSize = JSON.parse(firstSessionSize).value
+          let {height, width} = this.deviceSize
+
+          return this.handleRequest({
+            method: 'GET',
+            uri: `${this.baseUrl}/session/${this.sessionId}/wda/screen`,
+          })
+            .then((wdaScreenResponse) => {
+              const {scale} = JSON.parse(wdaScreenResponse).value
+
+              log.info(scale)
+
+              height *= scale
+              width *= scale
+
+              log.info('Storing device size/scale')
+
+              push.send([
+                  wireutil.global,
+                  wireutil.envelope(new wire.SizeIosDevice(
+                    options.serial,
+                    height,
+                    width,
+                    scale
+                  ))
+                ])
+
+              return this.deviceSize
+            })
+        })
+
         // #556: Get device size from RethinkDB
         return this.handleRequest({
           method: 'GET',
           uri: `${options.storageUrl}api/v1/devices/${options.serial}/size`,
         })
           .then((windowSizeResponse) => {
-              let {dbHeight, dbWidth, dbScale} = JSON.parse(windowSizeResponse)
+            let { height: dbHeight, width: dbWidth, scale: dbScale } = JSON.parse(windowSizeResponse);
 
-              // First device session 
+              // First device session:
               if (!dbHeight || !dbWidth || !dbScale) {
-                return this.handleRequest({
-                  method: 'GET',
-                  uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
-                }).then((firstSessionSize) => { 
-                  this.deviceSize = JSON.parse(firstSessionSize).value
-                  let {height, width} = this.deviceSize
-
-                  return this.handleRequest({
-                    method: 'GET',
-                    uri: `${this.baseUrl}/session/${this.sessionId}/wda/screen`,
-                  })
-                    .then((wdaScreenResponse) => {
-                      const {scale} = JSON.parse(wdaScreenResponse).value
-
-                      log.info(scale)
-
-                      height *= scale
-                      width *= scale
-
-                      log.info('Storing device size/scale')
-
-                      push.send([
-                          wireutil.global,
-                          wireutil.envelope(new wire.SizeIosDevice(
-                            options.serial,
-                            height,
-                            width,
-                            scale
-                          ))
-                        ])
-
-                      return this.deviceSize
-                    })
-                })
+                firstSession()
               } else {
+              // Reuse DB values:
                 log.info('Reusing device size/scale')
                 if (this.orientation === 'PORTRAIT') {
                   this.deviceSize = { height: dbHeight /= dbScale, width: dbWidth /= dbScale }  
@@ -508,6 +511,11 @@ module.exports = syrup.serial()
                 return this.deviceSize
               }
             })
+          .catch((err) => {
+            // #883: Track API errors if any
+            log.error(err)
+            return firstSession()
+          })
       },
       setVersion: function(currentSession) {
         log.info('Setting device version: ' + currentSession.value.capabilities.sdkVersion)


### PR DESCRIPTION
The following code returns `0` values for `width, height, scale` in API call if there are no values stored yet. 

It also improves the `size` method error handling to catch STF API errors (if any)