### PR TITLE
#846 save filtering on refresh

### DIFF
--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -27,7 +27,7 @@ module.exports = function DeviceScreenDirective(
     link: function($scope, $element) {
       // eslint-disable-next-line prefer-destructuring
       if ($scope.device.ios && $scope.device.present && (!$scope.device.display.width || !$scope.device.display.height)) {
-        Promise.delay(1000).then(() => window.location.reload())
+        Promise.delay(1000).then(() => $route.reload())
       }
       const element = $element[0]
       const URL = window.URL || window.webkitURL

--- a/res/app/device-list/details/device-list-details-directive.js
+++ b/res/app/device-list/details/device-list-details-directive.js
@@ -11,6 +11,7 @@ module.exports = function DeviceListDetailsDirective(
 , LightboxImageService
 , StandaloneService
 , LogcatService
+, $route
 ) {
   return {
     restrict: 'E'
@@ -255,8 +256,50 @@ module.exports = function DeviceListDetailsDirective(
 
       // Updates filters on visible items.
       function updateFilters(filters) {
-        activeFilters = filters
-        return filterAll()
+        let deviceFilters = JSON.parse(localStorage.getItem('deviceFilters'))
+
+        if (!deviceFilters) {
+          deviceFilters = []
+        }
+
+        // Use input filters
+        if (!deviceFilters[0]) {
+          activeFilters = filters
+          storeFilters(filters)
+          return filterAll()
+        }
+
+        // Use saved filters
+        if (deviceFilters[0] && !filters[0]) {
+          activeFilters = deviceFilters
+          return filterAll()
+        }
+
+        if (!deviceFilters[0] && !filters[0]) {
+          activeFilters = filters
+          return filterAll()
+        }
+
+        // Check if saved filter is the same as the current filter
+        if (deviceFilters[0] && filters[0] && deviceFilters[0].field === filters[0].field && deviceFilters[0].query === filters[0].query) {
+          activeFilters = deviceFilters
+          return filterAll()
+        }
+
+        // Check if they are different
+        if (deviceFilters[0] && filters[0] && (deviceFilters[0].field !== filters[0].field || deviceFilters[0].query !== filters[0].query)) {
+          activeFilters = filters
+          storeFilters(filters)
+          filterAll()
+          return storeRows()
+        } 
+
+      }
+
+      // Saves and updates filters on LocalStorage.
+      function storeFilters(filters) {
+        localStorage.removeItem('deviceFilters')
+        localStorage.setItem('deviceFilters', JSON.stringify(filters))
       }
 
       // Applies filterRow() to all rows.
@@ -611,7 +654,7 @@ module.exports = function DeviceListDetailsDirective(
         // correct order in the table.
         for (var i = 0, l = sorted.length; i < l; ++i) {
           tbody.appendChild(sorted[i])
-          storeRows()
+          // storeRows()
         }
 
       }
@@ -679,7 +722,7 @@ module.exports = function DeviceListDetailsDirective(
         }
 
         storeRows()
-
+        updateFilters(scope.filter())
       }
 
       // Triggers when the tracker notices that a device changed.

--- a/res/app/device-list/device-list-controller.js
+++ b/res/app/device-list/device-list-controller.js
@@ -12,6 +12,7 @@ module.exports = function DeviceListCtrl(
 , ControlService
 , SettingsService
 , $location
+, $route
 ) {
   $scope.tracker = DeviceService.trackAll($scope)
   $scope.control = ControlService.create($scope.tracker.devices, '*ALL')
@@ -221,6 +222,12 @@ module.exports = function DeviceListCtrl(
   }
 
   $scope.applyFilter = function(query) {
+    if (!query) {
+      localStorage.removeItem('deviceFilters')
+      localStorage.setItem('deviceFilters', JSON.stringify([]))
+      $scope.filter = []
+      $route.reload()
+    }
     $scope.filter = QueryParser.parse(query)
   }
 
@@ -240,5 +247,15 @@ module.exports = function DeviceListCtrl(
     $scope.filter = []
     $scope.sort = defaultSort
     $scope.columns = defaultColumns
+    localStorage.removeItem('deviceFilters')
+    localStorage.setItem('deviceFilters', JSON.stringify([]))
+  }
+
+  let deviceFilters = JSON.parse(localStorage.getItem('deviceFilters')) || []
+
+  let filter = deviceFilters[0]
+
+  if (filter) {
+    $scope.search.deviceFilter = `${filter.field ? filter.field : ''}: ${filter.query ? filter.query : ''}`
   }
 }

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -281,8 +281,45 @@ module.exports = function DeviceListIconsDirective(
 
       // Updates filters on visible items.
       function updateFilters(filters) {
-        activeFilters = filters
-        return filterAll()
+        let deviceFilters = JSON.parse(localStorage.getItem('deviceFilters'))
+
+        // Use input filters
+        if (!deviceFilters[0]) {
+          activeFilters = filters
+          storeFilters(filters)
+          return filterAll()
+        }
+
+        // Use saved filters
+        if (deviceFilters[0] && !filters[0]) {
+          activeFilters = deviceFilters
+          return filterAll()
+        }
+
+        if (!deviceFilters[0] && !filters[0]) {
+          activeFilters = filters
+          return filterAll()
+        }
+
+        // Check if saved filter is the same as the current filter
+        if (deviceFilters[0] && filters[0] && deviceFilters[0].field === filters[0].field && deviceFilters[0].query === filters[0].query) {
+          activeFilters = deviceFilters
+          return filterAll()
+        }
+
+        // Check if they are different
+        if (deviceFilters[0] && filters[0] && (deviceFilters[0].field !== filters[0].field || deviceFilters[0].query !== filters[0].query)) {
+          activeFilters = filters
+          storeFilters(filters)
+          filterAll()
+        } 
+
+      }
+
+      // Saves and updates filters on LocalStorage.
+      function storeFilters(filters) {
+        localStorage.removeItem('deviceFilters')
+        localStorage.setItem('deviceFilters', JSON.stringify(filters))
       }
 
       // Applies filteItem() to all items.


### PR DESCRIPTION
The following PR uses `localStorage` to set user's filtering data. It also implements a better approach to reload with `route`.