### PR TITLE
#554 Set correct owner .env values, new STF API owner endpoint

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1611,6 +1611,16 @@ dbapi.getInstalledApplications = function(message) {
   return db.run(r.table('devices').get(message.serial))
 }
 
+dbapi.setDeviceGroupOwner = function(message) {
+  return db.run(r.table('devices').get(message.serial).update({
+    group: {
+      owner: {
+        email: process.env.STF_ADMIN_EMAIL,
+        name: process.env.STF_ADMIN_NAME
+      }
+  }}))  
+}
+
 dbapi.initializeIosDeviceState = function(publicIp, message) {
   const screenWsUrlPattern =
   message.provider.screenWsUrlPattern || `ws://${publicIp}:${message.ports.screenPort}/`
@@ -1677,6 +1687,8 @@ dbapi.initializeIosDeviceState = function(publicIp, message) {
         })
       })
     }
+
+    dbapi.setDeviceGroupOwner(message)
 
     return stats
   })

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -282,6 +282,26 @@ function getDeviceGroups(req, res) {
   })
 }
 
+function getDeviceOwner (req, res) {
+  var serial = req.swagger.params.serial.value
+  dbapi.getDeviceGroupOwner(serial)
+  .then(response => {
+    if (!response) {
+      return res.status(404).json({
+        success: false, 
+        description: 'Device not found'
+      })
+    }
+    return res.status(200).json(response)
+  })
+  .catch(function(err) {
+    log.info('Failed to get device owner: ', err.stack)
+    res.status(500).json({
+      success: false
+    })
+  })
+}
+
 function getDeviceBookings(req, res) {
   const serial = req.swagger.params.serial.value
   const fields = req.swagger.params.fields.value
@@ -576,6 +596,7 @@ module.exports = {
 , putDeviceBySerial: putDeviceBySerial
 , getDeviceBySerial: getDeviceBySerial
 , getDeviceSize: getDeviceSize
+, getDeviceOwner: getDeviceOwner
 , getDeviceGroups: getDeviceGroups
 , getDeviceBookings: getDeviceBookings
 , addOriginGroupDevice: addOriginGroupDevice

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -2031,6 +2031,32 @@ paths:
             $ref: "#/definitions/UnexpectedErrorResponse"
       security:
         - accessTokenAuth: []
+  /devices/{serial}/owner:
+    x-swagger-router-controller: devices
+    get:
+      summary: Gets the group owner of a device
+      description: Gets the group owner of a device
+      operationId: getDeviceOwner
+      tags:
+        - user
+      parameters:
+        - name: serial
+          in: path
+          description: Device identifier (serial)
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Device size information
+          schema:
+            $ref: "#/definitions/OwnerResponse"
+        default:
+          description: >
+            Unexpected Error:
+              * 404: Not Found => unknown device
+              * 500: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /devices/{serial}/groups:
     x-swagger-router-controller: devices
     get:
@@ -2366,6 +2392,15 @@ definitions:
         type: integer
       width:
         type: integer
+  OwnerResponse:
+    required:
+      - email
+      - name
+    properties:
+      email: 
+        type: string
+      name:
+        type: string
   DeviceResponse:
     required:
       - success


### PR DESCRIPTION
The following PR allows to: 

1. Show correct group owner values in STF
2. Get group owner values from STF API in: `{baseUrl}/api/v1/devices/{serial}/owner`

This endpoint is necessary to get those values in agent servers.