### PR TITLE
#897 Detecting device type from DB without breaking functionalities

### DIFF
--- a/lib/cli/ios-device/index.js
+++ b/lib/cli/ios-device/index.js
@@ -178,11 +178,6 @@ module.exports.builder = function(yargs) {
     , type: 'string'
     , default: false
   })
-  .option('device-type', {
-    describe: 'Device type'
-    , type: 'string'
-    , default: false
-  })
   .option('host', {
     describe: 'Provider hostname.'
   , type: 'string'
@@ -225,7 +220,6 @@ module.exports.handler = function(argv) {
     , udidStorage: argv.udidStorage
     , iproxy: argv.iproxy
     , deviceName: argv.deviceName
-    , deviceType: argv.deviceType
     , host: argv.host
   })
 }

--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -1129,6 +1129,8 @@ dbapi.saveDeviceLog = function(serial, entry) {
 }
 
 dbapi.saveDeviceInitialState = function(serial, device) {
+  const storedDeviceType = dbapi.getDeviceType(message.serial)
+
   var data = {
     present: true
   , presenceChangedAt: r.now()
@@ -1142,6 +1144,7 @@ dbapi.saveDeviceInitialState = function(serial, device) {
   , remoteConnectUrl: null
   , usage: null
   , logs_enabled: false
+  , deviceType: storedDeviceType
   }
   return db.run(r.table('devices').get(serial).update(data)).then(function(stats) {
     if (stats.skipped) {
@@ -1623,6 +1626,16 @@ dbapi.setDeviceGroupOwner = function(message) {
         name: process.env.STF_ADMIN_NAME
       }
   }}))  
+}
+
+dbapi.setDeviceType = function(message) {
+  return db.run(r.table('devices').get(message.serial).update({
+    deviceType: message.type
+  }))
+}
+
+dbapi.getDeviceType = function(serial) {
+  return db.run(r.table('devices').get(serial).pluck('deviceType'))
 }
 
 dbapi.initializeIosDeviceState = function(publicIp, message) {

--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -302,6 +302,26 @@ function getDeviceOwner (req, res) {
   })
 }
 
+function getDeviceType (req, res) {
+  var serial = req.swagger.params.serial.value
+  dbapi.getDeviceType(serial)
+  .then(response => {
+    if (!response) {
+      return res.status(404).json({
+        success: false, 
+        description: 'Device not found'
+      })
+    }
+    return res.status(200).json(response)
+  })
+  .catch(function(err) {
+    log.info('Failed to get device type: ', err.stack)
+    res.status(500).json({
+      success: false
+    })
+  })
+}
+
 function getDeviceBookings(req, res) {
   const serial = req.swagger.params.serial.value
   const fields = req.swagger.params.fields.value
@@ -598,6 +618,7 @@ module.exports = {
 , getDeviceSize: getDeviceSize
 , getDeviceOwner: getDeviceOwner
 , getDeviceGroups: getDeviceGroups
+, getDeviceType: getDeviceType
 , getDeviceBookings: getDeviceBookings
 , addOriginGroupDevice: addOriginGroupDevice
 , addOriginGroupDevices: addOriginGroupDevices

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -2091,6 +2091,32 @@ paths:
             $ref: "#/definitions/UnexpectedErrorResponse"
       security:
         - accessTokenAuth: []
+  /devices/{serial}/type: 
+    x-swagger-router-controller: devices
+    get:
+      summary: Gets the type of a device
+      description: Gets the type of a device
+      operationId: getDeviceType
+      tags:
+        - user
+      parameters:
+        - name: serial
+          in: path
+          description: Device identifier (serial)
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Device type information
+          schema:
+            $ref: "#/definitions/TypeResponse"
+        default:
+          description: >
+            Unexpected Error:
+              * 404: Not Found => unknown device
+              * 500: Internal Server Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /devices/{serial}/bookings:
     x-swagger-router-controller: devices
     get:
@@ -2400,6 +2426,12 @@ definitions:
       email: 
         type: string
       name:
+        type: string
+  TypeResponse:
+    required:
+      - type
+    properties:
+      type:
         type: string
   DeviceResponse:
     required:

--- a/lib/units/ios-device/plugins/info/index.js
+++ b/lib/units/ios-device/plugins/info/index.js
@@ -16,9 +16,10 @@ module.exports = syrup.serial()
         let solo = wireutil.makePrivateChannel()
 
         let osName = "iOS"
-        if (options.deviceType === "tvOS") {
+        if (options.deviceName.includes('TV') || options.deviceName.includes('tv')) {
           osName = "tvOS"
         }
+
         push.send([
           wireutil.global
           , wireutil.envelope(new wire.InitializeIosDeviceState(
@@ -45,7 +46,7 @@ module.exports = syrup.serial()
         return resolve()
       })
       .catch(err => {
-        return reject()
+        return reject(err)
       })
     }
     return {

--- a/lib/units/ios-device/plugins/info/index.js
+++ b/lib/units/ios-device/plugins/info/index.js
@@ -16,7 +16,7 @@ module.exports = syrup.serial()
         let solo = wireutil.makePrivateChannel()
 
         let osName = "iOS"
-        if (options.deviceName.includes('TV') || options.deviceName.includes('tv')) {
+        if (options.deviceName.toLowercase().includes("tv")) {
           osName = "tvOS"
         }
 

--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -101,7 +101,7 @@ module.exports = syrup.serial()
               log.important('ws on close event')
             }
             
-            if (options.deviceType === 'tvOS' || orientation === 'PORTRAIT') {
+            if (WdaClient.deviceType === 'Apple TV' || orientation === 'PORTRAIT') {
               return stoppingSession()
             } 
 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -32,7 +32,39 @@ module.exports = syrup.serial()
       upperCase: false,
       isSwiping: false,
       isRotating: false,
+      deviceType: null,
 
+      getDeviceType: function() {
+        const setDeviceTypeInDB = () => {
+          this.handleRequest({
+            method: 'GET',
+            uri: `${this.baseUrl}/wda/device/info`,
+            json: true
+          }).then((deviceInfo) => {
+            log.info('Setting device type value: ' + deviceInfo.value.model)
+            this.deviceType = deviceInfo.value.model
+  
+            return push.send([
+              wireutil.global,
+              wireutil.envelope(new wire.DeviceTypeMessage(
+                options.serial,
+                deviceInfo.value.model
+              ))
+            ])
+          })
+        }
+        return this.handleRequest({
+          method: 'GET',
+          uri: `${options.storageUrl}api/v1/devices/${options.serial}/type`,
+        }).then((response) => {
+          let deviceType = JSON.parse(response).deviceType
+          if (!deviceType) {
+            return setDeviceTypeInDB()
+          }
+
+          log.info('Reusing device type value: ', deviceType)
+          this.deviceType = deviceType
+      })},      
       startSession: function() {
         log.info('verifying wda session status...')
 
@@ -57,19 +89,19 @@ module.exports = syrup.serial()
 
               // handles case of existing session
               if (statusResponse.sessionId) {
-
-                this.setStatus(3)
-
                 this.sessionId = statusResponse.sessionId
                 log.info(`reusing existing wda session: ${this.sessionId}`)
-                
-                if (options.deviceType !== 'tvOS') {
-                  this.getOrientation()
-                }
 
-                this.setVersion(sessionResponse)
-                
-                return this.size()
+                this.setStatus(3)
+                this.getDeviceType().then((response) => {
+                  if (this.deviceType !== 'Apple TV') {
+                    this.getOrientation()
+                  }
+  
+                  this.setVersion(sessionResponse)
+                  
+                  return this.size()
+                })                
               }
 
               log.info('starting wda session...')
@@ -92,15 +124,17 @@ module.exports = syrup.serial()
                   // #284 send info about battery to STF db
                   log.info(`sessionId: ${this.sessionId}`)
 
-                  // Prevent Apple TV disconnection
-                  if (options.deviceType !== 'tvOS') {
-                    this.getOrientation()
-                    this.batteryIosEvent()
-                  }
+                  this.getDeviceType().then((response) => {
+                    // Prevent Apple TV disconnection
+                    if (this.deviceType !== 'Apple TV') {
+                      this.getOrientation()
+                      this.batteryIosEvent()
+                    }
 
-                  this.setStatus(3)
+                    this.setStatus(3)
 
-                  return this.size()
+                    return this.size()
+                  })
                 })
                 .catch((err) => {
                   log.error('"startSession" No valid response from web driver!', err)
@@ -176,7 +210,7 @@ module.exports = syrup.serial()
             this.typeKeyTimerId = null
           }
 
-          if (options.deviceType !== 'tvOS') {
+          if (this.deviceType !== 'Apple TV') {
             return this.handleRequest(requestParams)
           } 
 
@@ -252,7 +286,7 @@ module.exports = syrup.serial()
         this.touchDownParams = params
       },
       homeBtn: function() {
-        if (options.deviceType !== 'tvOS') {
+        if (this.deviceType !== 'Apple TV') {
           return this.handleRequest({
             method: 'POST',
             uri: `${this.baseUrl}/session/${this.sessionId}/wda/pressButton`,
@@ -289,7 +323,7 @@ module.exports = syrup.serial()
           ],
         }
 
-        if (options.deviceType === 'tvOS') {
+        if (this.deviceType === 'Apple TV') {
           return log.error('Swipe is not supported')
         }
 
@@ -334,7 +368,7 @@ module.exports = syrup.serial()
                 ],
               }
 
-            if (options.deviceType !== 'tvOS') {
+            if (this.deviceType !== 'Apple TV') {
               log.info(options.deviceName)
               return this.handleRequest({
                 method: 'POST',
@@ -396,7 +430,7 @@ module.exports = syrup.serial()
             }
           }
           else {
-            if (options.deviceType === 'tvOS') {
+            if (this.deviceType === 'Apple TV') {
               return log.error('Holding tap is not supported')
             }
             return this.handleRequest({
@@ -454,7 +488,7 @@ module.exports = syrup.serial()
       size: function() {
         log.info('getting device window size...')
 
-        const firstSession = () => this.handleRequest({
+        const setSizeInDB = () => this.handleRequest({
           method: 'GET',
           uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
         }).then((firstSessionSize) => { 
@@ -499,7 +533,7 @@ module.exports = syrup.serial()
 
               // First device session:
               if (!dbHeight || !dbWidth || !dbScale) {
-                firstSession()
+                setSizeInDB()
               } else {
               // Reuse DB values:
                 log.info('Reusing device size/scale')
@@ -507,6 +541,8 @@ module.exports = syrup.serial()
                   this.deviceSize = { height: dbHeight /= dbScale, width: dbWidth /= dbScale }  
                 } else if (this.orientation === 'LANDSCAPE') {
                   this.deviceSize = { height: dbWidth /= dbScale, width: dbHeight /= dbScale }
+                } else if (this.deviceType === 'Apple TV') {
+                  this.deviceSize = { height: dbHeight, width: dbWidth }
                 }
                 return this.deviceSize
               }
@@ -514,7 +550,7 @@ module.exports = syrup.serial()
           .catch((err) => {
             // #883: Track API errors if any
             log.error(err)
-            return firstSession()
+            return setSizeInDB()
           })
       },
       setVersion: function(currentSession) {

--- a/lib/units/processor/index.js
+++ b/lib/units/processor/index.js
@@ -427,6 +427,17 @@ module.exports = db.ensureConnectivity(function(options) {
             log.info(err)
           })
       })
+      .on(wire.DeviceTypeMessage, function(channel, message, data) {
+        dbapi
+          .setDeviceType(message)
+          .then(result => {
+            log.info(result)
+          })
+          .catch(err => {
+            log.info(err)
+          })
+      
+      })
       .on(wire.DeleteIosDevice, function(channel, message) {
         dbapi.deleteIosDevice(message)
       })

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -17,6 +17,7 @@ enum MessageType {
   DevicePropertiesMessage           = 7;
   DeviceRegisteredMessage           = 8;
   DeviceStatusMessage               = 9;
+  DeviceTypeMessage                 = 20;
   GroupMessage                      = 10;
   InstallMessage                    = 30;
   PhysicalIdentifyMessage           = 29;
@@ -422,6 +423,11 @@ enum DeviceStatus {
 message DeviceStatusMessage {
   required string serial = 1;
   required DeviceStatus status = 2;
+}
+
+message DeviceTypeMessage {
+  required string serial = 1;
+  required string type = 2;
 }
 
 message DeviceDisplayMessage {


### PR DESCRIPTION
The following PR includes:

1. Removing `device-type` detection from `ios-device` cli args. Instead, using `wdaClient.deviceType`.
2. Using `deviceType` property from DB and use it in WdaClient (`wdaClient.deviceType = response.deviceType`)
3. Setting `deviceType` property in RethinkDB if it doesn't exist.
4. Review all exceptional cases for AppleTV to use `wdaClient.deviceType`  
5. A new endpoint for STF API: `<baseUrl>/api/v1/devices/<udid>/type`. Which returns: `{"deviceType": "iPhone"}` or `{"deviceType": "Apple TV"}` on success.
6. A new `dbapi.getDeviceType(serial)` method which returns the device type.