### PR TITLE
#556 Using webapi method and detecting null orientation

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -503,7 +503,8 @@ module.exports = syrup.serial()
               } else {
               // Reuse DB values:
                 log.info('Reusing device size/scale')
-                if (this.orientation === 'PORTRAIT') {
+                // Set device size based on orientation, default is PORTRAIT
+                if (this.orientation === 'PORTRAIT' || !this.orientation) {
                   this.deviceSize = { height: dbHeight /= dbScale, width: dbWidth /= dbScale }  
                 } else if (this.orientation === 'LANDSCAPE') {
                   this.deviceSize = { height: dbWidth /= dbScale, width: dbHeight /= dbScale }

--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -27,7 +27,7 @@ module.exports = function DeviceScreenDirective(
     link: function($scope, $element) {
       // eslint-disable-next-line prefer-destructuring
       if ($scope.device.ios && $scope.device.present && (!$scope.device.display.width || !$scope.device.display.height)) {
-        Promise.delay(1000).then(() => $route.reload())
+        return Promise.delay(1000).then(() => window.location.reload())
       }
       const element = $element[0]
       const URL = window.URL || window.webkitURL


### PR DESCRIPTION
The following PR implements a valid `window` method to use with mcloud-device containers and properly set DB size/scale values. 