### PR TITLE
#911 catch error correctly in device info.

### DIFF
--- a/lib/units/ios-device/plugins/info/index.js
+++ b/lib/units/ios-device/plugins/info/index.js
@@ -14,9 +14,10 @@ module.exports = syrup.serial()
         log.info("device.name: " + options.deviceName)
 
         let solo = wireutil.makePrivateChannel()
-
         let osName = "iOS"
-        if (options.deviceName.toLowercase().includes("tv")) {
+        let deviceName = options.deviceName.toLowerCase()
+
+        if (deviceName.includes("tv")) {
           osName = "tvOS"
         }
 
@@ -46,7 +47,7 @@ module.exports = syrup.serial()
         return resolve()
       })
       .catch(err => {
-        return reject(err)
+        return log.error(err, 'Failed to manage device info')
       })
     }
     return {


### PR DESCRIPTION
The following PR excludes `reject` from the catch method. Since the first must be inside the promise context.