### PR TITLE
#556 and #897 fixes on first session, defining error messages correctly

### DIFF
--- a/lib/units/api/controllers/devices.js
+++ b/lib/units/api/controllers/devices.js
@@ -306,19 +306,11 @@ function getDeviceType (req, res) {
   var serial = req.swagger.params.serial.value
   dbapi.getDeviceType(serial)
   .then(response => {
-    if (!response) {
-      return res.status(404).json({
-        success: false, 
-        description: 'Device not found'
-      })
-    }
     return res.status(200).json(response)
   })
   .catch(function(err) {
     log.info('Failed to get device type: ', err.stack)
-    res.status(500).json({
-      success: false
-    })
+    return res.status(200).json({deviceType: null})
   })
 }
 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -34,32 +34,37 @@ module.exports = syrup.serial()
       isRotating: false,
       deviceType: null,
 
-      getDeviceType: function() {
-        const setDeviceTypeInDB = () => {
-          this.handleRequest({
-            method: 'GET',
-            uri: `${this.baseUrl}/wda/device/info`,
-            json: true
-          }).then((deviceInfo) => {
-            log.info('Setting device type value: ' + deviceInfo.value.model)
-            this.deviceType = deviceInfo.value.model
-  
-            return push.send([
-              wireutil.global,
-              wireutil.envelope(new wire.DeviceTypeMessage(
-                options.serial,
-                deviceInfo.value.model
-              ))
-            ])
-          })
-        }
+      setDeviceTypeInDB: function() {
+        this.handleRequest({
+          method: 'GET',
+          uri: `${this.baseUrl}/wda/device/info`,
+          json: true
+        }).then((deviceInfo) => {
+          log.info('Storing device type value: ' + deviceInfo.value.model)
+          this.deviceType = deviceInfo.value.model
+
+          return push.send([
+            wireutil.global,
+            wireutil.envelope(new wire.DeviceTypeMessage(
+              options.serial,
+              deviceInfo.value.model
+            ))
+          ])
+        })
+      },
+      getDeviceType: function(onFirstSession) {
         return this.handleRequest({
           method: 'GET',
           uri: `${options.storageUrl}api/v1/devices/${options.serial}/type`,
         }).then((response) => {
           let deviceType = JSON.parse(response).deviceType
+
+          if (onFirstSession && !deviceType) {
+            return null
+          }
+
           if (!deviceType) {
-            return setDeviceTypeInDB()
+            return this.setDeviceTypeInDB()
           }
 
           log.info('Reusing device type value: ', deviceType)
@@ -93,7 +98,7 @@ module.exports = syrup.serial()
                 log.info(`reusing existing wda session: ${this.sessionId}`)
 
                 this.setStatus(3)
-                this.getDeviceType().then((response) => {
+                this.getDeviceType(false).then((response) => {
                   if (this.deviceType !== 'Apple TV') {
                     this.getOrientation()
                   }
@@ -124,7 +129,7 @@ module.exports = syrup.serial()
                   // #284 send info about battery to STF db
                   log.info(`sessionId: ${this.sessionId}`)
 
-                  this.getDeviceType().then((response) => {
+                  this.getDeviceType(false).then((response) => {
                     // Prevent Apple TV disconnection
                     if (this.deviceType !== 'Apple TV') {
                       this.getOrientation()
@@ -485,10 +490,8 @@ module.exports = syrup.serial()
           })
         }
       },
-      size: function() {
-        log.info('getting device window size...')
-
-        const setSizeInDB = () => this.handleRequest({
+      setSizeInDB: function() {
+        return this.handleRequest({
           method: 'GET',
           uri: `${this.baseUrl}/session/${this.sessionId}/window/size`,
         }).then((firstSessionSize) => { 
@@ -522,6 +525,9 @@ module.exports = syrup.serial()
               return this.deviceSize
             })
         })
+      },
+      size: function() {
+        log.info('getting device window size...')
 
         // #556: Get device size from RethinkDB
         return this.handleRequest({
@@ -530,10 +536,9 @@ module.exports = syrup.serial()
         })
           .then((windowSizeResponse) => {
             let { height: dbHeight, width: dbWidth, scale: dbScale } = JSON.parse(windowSizeResponse);
-
               // First device session:
               if (!dbHeight || !dbWidth || !dbScale) {
-                setSizeInDB()
+                return this.setSizeInDB()
               } else {
               // Reuse DB values:
                 log.info('Reusing device size/scale')
@@ -597,7 +602,6 @@ module.exports = syrup.serial()
         })
       },
       getOrientation: function() {
-
         return this.handleRequest({
           method: 'GET',
           uri: `${this.baseUrl}/session/${this.sessionId}/orientation`,
@@ -737,7 +741,11 @@ module.exports = syrup.serial()
               return resolve(response)
             })
             .catch(err => {
-              let errMes = err.error.value.message ? err.error.value.message : ''
+              let errMes = ''
+
+              if (err.error.value.message) {
+                errMes = err.error.value.message
+              }
 
               // #762 & #864: Skip lock/unlock error messages 
               if (errMes.includes('Timed out while waiting until the screen gets locked') || errMes.includes('unlocked')) {
@@ -767,9 +775,11 @@ module.exports = syrup.serial()
      * WDA MJPEG connection is stable enough to be track status wda server itself.
      * As only connection is closed or error detected we have to restart STF
     */
-    function connectToWdaMjpeg() {
+    function connectToWdaMjpeg(options) {
       console.log('connecting to WdaMjpeg')
-      socket.connect(options.connectPort, options.wdaHost)
+      socket.connect(options.connectPort, options.wdaHost, () => {
+        console.log(`Connected to WdaMjpeg ${options.wdaHost}:${options.connectPort}`)
+      })
 
       // #410: Use status 6 (preparing) on WDA startup
       push.send([
@@ -779,10 +789,13 @@ module.exports = syrup.serial()
           6
         ))
       ])
-    }
 
-    function wdaMjpegConnectEventHandler() {
-      console.log(`Connected to WdaMjpeg ${options.wdaHost}:${options.connectPort}`)
+      WdaClient.getDeviceType(true).then((response) => {
+        if (response === null) {
+          log.info('First session started')
+          return WdaClient.startSession()
+        }
+      })
     }
 
     async function wdaMjpegCloseEventHandler(hadError) {
@@ -799,7 +812,6 @@ module.exports = syrup.serial()
       ])
     }
 
-    socket.on('connect', wdaMjpegConnectEventHandler)
     socket.on('close', wdaMjpegCloseEventHandler)
     connectToWdaMjpeg(options)
 


### PR DESCRIPTION
The following PR handles the first device session and awaits for the values to be set, and handles the case where `deviceType` does not exist in DB yet. It also improves WdaClient socket connection code and prevents crashes when `err.error.value.message` does not exist