### PR TITLE
#556 and #897 catch errors in STF API calls, improve connectToWdaMjpeg method

### DIFF
--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -43,13 +43,15 @@ module.exports = syrup.serial()
           log.info('Storing device type value: ' + deviceInfo.value.model)
           this.deviceType = deviceInfo.value.model
 
-          return push.send([
+          push.send([
             wireutil.global,
             wireutil.envelope(new wire.DeviceTypeMessage(
               options.serial,
               deviceInfo.value.model
             ))
           ])
+
+          return this.deviceType
         })
       },
       getDeviceType: function() {

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -69,6 +69,9 @@ module.exports = syrup.serial()
 
           log.info('Reusing device type value: ', deviceType)
           this.deviceType = deviceType
+        }).catch((err) => {
+          log.error('Error getting device type from DB')
+          return lifecycle.fatal(err)
         })
       },
       startSession: function() {
@@ -78,7 +81,7 @@ module.exports = syrup.serial()
           capabilities: {},
         }
 
-        this.handleRequest({
+        return this.handleRequest({
           method: 'POST',
           uri: `${this.baseUrl}/session`,
           body: params,
@@ -531,10 +534,6 @@ module.exports = syrup.serial()
         })
           .then((windowSizeResponse) => {
             let { height: dbHeight, width: dbWidth, scale: dbScale } = JSON.parse(windowSizeResponse);
-              // First device session:
-              if (!dbHeight || !dbWidth || !dbScale) {
-                return this.setSizeInDB()
-              } else {
               // Reuse DB values:
                 log.info('Reusing device size/scale')
                 // Set device size based on orientation, default is PORTRAIT
@@ -546,12 +545,11 @@ module.exports = syrup.serial()
                   this.deviceSize = { height: dbHeight, width: dbWidth }
                 }
                 return this.deviceSize
-              }
             })
           .catch((err) => {
             // #883: Track API errors if any
-            log.error(err)
-            return setSizeInDB()
+            log.error('Error getting device size from DB')
+            return lifecycle.fatal(err)
           })
       },
       setVersion: function(currentSession) {
@@ -738,7 +736,7 @@ module.exports = syrup.serial()
             .catch(err => {
               let errMes = ''
 
-              if (err.error.value.message) {
+              if (err?.error?.value?.message) {
                 errMes = err.error.value.message
               }
 
@@ -785,13 +783,12 @@ module.exports = syrup.serial()
         ))
       ])
 
-      //TODO: handle negative case when device type not detected. Seems lifecycle.fatal(err) is ok.
       WdaClient.getDeviceType()
-
-      //TODO: start session, init size/scale and stop session asap. Improve size getting info from db only
-      //WdaClient.startSession()
-      //WdaClient.setSizeInDB()
-      //WdaClient.stopSession()
+      WdaClient.startSession().then(() => {
+        WdaClient.setSizeInDB().then(() => {
+          WdaClient.stopSession()
+        })
+      })
     }
 
     async function wdaMjpegCloseEventHandler(hadError) {


### PR DESCRIPTION
The following PR implements: 

- Catching error cases correctly for STF API calls (in `size` and `getDeviceType` methods
- Using optional chaining operator to check the `err` object properties first
- Handling `WdaClient.startSession` asynchronously
- Returning `this.deviceType` after being stored in DB (same as size)