### PR TITLE
#853 Implement tvOS bundleIds, improve iosutil

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -56,6 +56,16 @@ let iosutil = {
   },
   pressButton: function(key) {
     switch (key) {
+      case 'settings':
+        if (this.deviceType === 'Apple TV') {
+          return this.appActivate('com.apple.TVSettings')
+        }
+        return this.appActivate('com.apple.Preferences')
+      case 'store':
+        if (this.deviceType === 'Apple TV') {
+          return this.appActivate('com.apple.TVAppStore')
+        }
+        return this.appActivate('com.apple.AppStore')
       case 'volume_up':
         return this.pressButton('volumeUp')
       case 'volume_down':
@@ -65,6 +75,9 @@ let iosutil = {
       case 'camera':
         return this.appActivate('com.apple.camera')
       case 'search':
+        if (this.deviceType === 'Apple TV') {
+          return this.appActivate('com.apple.TVSearch')
+        }
         return this.appActivate('com.apple.mobilesafari')
       case 'finder':
         return this.appActivate('com.apple.findmy')

--- a/lib/units/ios-device/plugins/wda.js
+++ b/lib/units/ios-device/plugins/wda.js
@@ -33,13 +33,13 @@ module.exports = syrup.serial()
         iosutil.pressButton.call(wdaClient, message.key)
       })
       .on(wire.StoreOpenMessage, (channel, message) => {
-        wdaClient.appActivate('com.apple.AppStore')
+        iosutil.pressButton.call(wdaClient, 'store')
       })
       .on(wire.DashboardOpenMessage, (channel, message) =>{
-        wdaClient.appActivate('com.apple.Preferences')
+        iosutil.pressButton.call(wdaClient, 'settings')
       })
       .on(wire.PhysicalIdentifyMessage, (channel, message) =>{
-        wdaClient.appActivate('com.apple.findmy')
+        iosutil.pressButton.call(wdaClient, 'finder')
       })
       .on(wire.TouchDownIosMessage, (channel, message) => {
         wdaClient.tap(message)

--- a/res/app/control-panes/info/info.pug
+++ b/res/app/control-panes/info/info.pug
@@ -7,7 +7,7 @@
         stacked-icon(icon='fa-location-arrow', color='color-pink')
         span(translate) Physical Device
         .pull-right
-          button(ng-click='device.ios ? press("finder") : finder()').btn.btn-xs.btn-primary-outline
+          button(ng-click='device.ios ? press("finder") : finder()', ng-disabled='device.platform === "tvOS"').btn.btn-xs.btn-primary-outline
             i.fa.fa-info
             span(translate) Find Device
 


### PR DESCRIPTION
The following PR implements correct bundleIds for tvOS applications: https://support.apple.com/guide/deployment/bundle-ids-for-native-apple-tv-apps-depcdd66fe58/web

And also handling every application/button case inside `iosutil`.