### PR TITLE
#934 Disable screenshot button for 3s

### DIFF
--- a/res/app/control-panes/screenshots/screenshots-controller.js
+++ b/res/app/control-panes/screenshots/screenshots-controller.js
@@ -6,6 +6,8 @@ module.exports = function ScreenshotsCtrl($scope) {
   $scope.screenshots = []
   $scope.screenShotSize = 400
 
+  let screenshotButtons = document.getElementsByClassName('btn btn-sm btn-primary-outline')
+
   $scope.clear = function() {
     $scope.screenshots = []
   }
@@ -24,6 +26,16 @@ module.exports = function ScreenshotsCtrl($scope) {
         $scope.screenshots.unshift(result)
       })
     })
+    Array.from(screenshotButtons).forEach((button) => {
+      button.setAttribute('disabled', 'disabled');
+      button.setAttribute('style', 'cursor: wait;')
+    });
+    setTimeout(function() {
+      Array.from(screenshotButtons).forEach((button) => {
+        button.removeAttribute('disabled')
+        button.setAttribute('style', 'cursor: pointer;')
+      });
+    }, 3000)
   }
 
   $scope.zoom = function(param) {


### PR DESCRIPTION
The following PR disables Screenshot button when clicked. After 3 seconds, it is enabled for use again.

This prevents overloading appium with screenshot requests and causing the `'Failed to grow buffer'` error