### PR TITLE
#930 Stop using and show 'Use' button correctly

### DIFF
--- a/res/app/control-panes/device-control/device-control-controller.js
+++ b/res/app/control-panes/device-control/device-control-controller.js
@@ -1,7 +1,7 @@
 var _ = require('lodash')
 
 module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
-  $location, $timeout, $window, $rootScope, LogcatService) {
+  $location, $timeout, $window, $rootScope, LogcatService, $route) {
 
   $scope.showScreen = true
 
@@ -54,6 +54,9 @@ module.exports = function DeviceControlCtrl($scope, DeviceService, GroupService,
             $scope.$digest()
           })
           $location.path('/devices/')
+          setTimeout(function() {
+            $route.reload()
+          }, 50)
         }
       } else {
         GroupService.kick(device).then(function() {

--- a/res/app/menu/menu-controller.js
+++ b/res/app/menu/menu-controller.js
@@ -15,7 +15,7 @@ module.exports = function MenuCtrl(
 , $window
 , $route) {
 
-  const contactEmail = 'support@zebrunner.com'
+  let contactEmail = 'support@zebrunner.com'
 
   SettingsService.bind($scope, {
     target: 'lastUsedDevice'


### PR DESCRIPTION
The following PR allows to reload the device data state, in order to handle the `device.using` property as false. 
It also fixes a console error for the contact email variable.