### PR TITLE
Testing: increasing provider timeout to 30000ms

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -71,7 +71,7 @@ module.exports = function(options) {
 
     return function() {
       clearTimeout(totalsTimer)
-      totalsTimer = setTimeout(totals, 10000)
+      totalsTimer = setTimeout(totals, 30000)
     }
   })()
 


### PR DESCRIPTION
The following PR replaces the provider `totalsTimer` timeout from 10s to 30s