### PR TITLE
#938 Temporary disabling mute button after use

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const logger = require('../../../../util/logger')
+const { Promise } = require('bluebird')
 
 var log = logger.createLogger('iosutil')
 
@@ -85,8 +86,10 @@ let iosutil = {
         return this.homeBtn()
       case 'mute': {
         let i
-          for(i = 0; i < 25; i++) {
-            this.pressButton('volumeDown')
+          for (i = 0; i < 16; i++) {
+            Promise.delay(1000).then(() => {
+              this.pressButton('volumeDown')
+            })
           }
           return true }
       case 'switch_charset': {

--- a/res/app/control-panes/advanced/input/input-controller.js
+++ b/res/app/control-panes/advanced/input/input-controller.js
@@ -1,5 +1,22 @@
 module.exports = function InputCtrl($scope) {
 
+  let muteButton = document.getElementById('muteButton')
+
+  muteButton.onclick = function() {
+    if (muteButton.getAttribute('disabled')) {
+      return
+    }
+
+    $scope.control.keyPress('mute')
+    muteButton.setAttribute('disabled', 'disabled')
+    muteButton.setAttribute('style', 'cursor: wait;')    
+
+    setTimeout(function() {
+      muteButton.removeAttribute('disabled')
+      muteButton.setAttribute('style', 'cursor: pointer;')
+    }, 16000)
+  } 
+
   $scope.press = function(key) {
     $scope.control.keyPress(key)
   }

--- a/res/app/control-panes/advanced/input/input.pug
+++ b/res/app/control-panes/advanced/input/input.pug
@@ -17,7 +17,7 @@
 
         h6(translate) Volume
         .btn-group
-          button(uib-tooltip='{{ "Mute" | translate }}', ng-click='press("mute")').btn.btn-primary.btn-xs
+          button(uib-tooltip='{{ "Mute" | translate }}' id='muteButton').btn.btn-primary.btn-xs
             i.fa.fa-volume-off
           button(uib-tooltip='{{ "Volume Down" | translate }}', ng-click='press("volume_down")').btn.btn-primary.btn-xs
             i.fa.fa-volume-down


### PR DESCRIPTION
The following PR disables mute button for 16s after use, and a small delay between every `pressButton` request.

This prevents overloading appium with `pressButton` requests and causing the 'Failed to grow buffer' error