### PR TITLE
#944 Make 'Details' and 'Customize' visible in Mobile

### DIFF
--- a/res/app/components/stf/basic-mode/basic-mode.css
+++ b/res/app/components/stf/basic-mode/basic-mode.css
@@ -39,3 +39,13 @@
 .guest-landscape .basic-mode .fill-height {
   width: 100%;
 }
+
+@media (max-width: 767px) {
+  .basic-mode .stf-device-list .device-search {
+    width: 8em;
+  }
+  .pull-right > .dropdown-menu {
+    left: -140px;
+    right: auto;
+  }
+}

--- a/res/app/control-panes/control-panes.pug
+++ b/res/app/control-panes/control-panes.pug
@@ -1,5 +1,5 @@
 div(ng-controller='ControlPanesHotKeysCtrl').fill-height
-  div(ng-if='$root.basicMode || $root.standalone').fill-height
+  div().fill-height
     div.fill-height.basic-remote-control
       .remote-control
         div(ng-include='"control-panes/device-control/device-control-standalone.pug"').fill-height

--- a/res/app/device-list/device-list.pug
+++ b/res/app/device-list/device-list.pug
@@ -22,7 +22,7 @@
               list='searchFields', multiple,
               text-focus-select, accesskey='4').form-control.input-sm.device-search.pull-right
 
-            span.pull-right(ng-if='activeTabs.details && !$root.basicMode')
+            span.pull-right(ng-if='activeTabs.details')
               .btn-group(uib-dropdown).pull-right
                 button.btn.btn-sm.btn-primary-outline(type='button', uib-dropdown-toggle)
                   i.fa.fa-columns
@@ -44,15 +44,15 @@
             uib-tab(active='activeTabs.icons', select='focusSearch()')
               uib-tab-heading
                 i.fa.fa-th-large
-                span(translate) Devices
+                span(ng-if='!$root.basicMode', translate) Devices
               div.device-list-devices-content(ng-if='activeTabs.icons').selectable
 
                 device-list-icons(tracker='tracker', columns='columns', sort='sort', filter='filter')
 
-            uib-tab(active='activeTabs.details', select='focusSearch()', ng-if='!$root.basicMode')
+            uib-tab(active='activeTabs.details', select='focusSearch()')
               uib-tab-heading
                 i.fa.fa-list
-                span(translate) Details
+                span(ng-if='!$root.basicMode', translate) Details
               div.device-list-details-content(ng-if='activeTabs.details').selectable
 
                 device-list-details(tracker='tracker', columns='columns', sort='sort', filter='filter').selectable


### PR DESCRIPTION
The following PR allows to see/use the `Details` and `Customize` buttons with adapted styles for mobile