### PR TITLE
#967 Set device type based on model or name

### DIFF
--- a/lib/units/ios-device/plugins/group.js
+++ b/lib/units/ios-device/plugins/group.js
@@ -81,8 +81,15 @@ module.exports = syrup.serial()
                 json: true
               })
                 .then((deviceInfo) => {
-                  log.info('Storing device type value: ' + deviceInfo.value.model)
-                  let = deviceType = deviceInfo.value.model  
+                  let deviceInfoModel = deviceInfo.value.model.toLowerCase()
+                  let deviceInfoName = deviceInfo.value.name.toLowerCase()
+                  let deviceType
+                  if (deviceInfoModel.includes("tv") || deviceInfoName.includes("tv")) {
+                    deviceType = "Apple TV"
+                  } else {
+                    deviceType = "iPhone"
+                  }
+                  log.info('Storing device type value: ' + deviceType)
                   dbapi.setDeviceType(options.serial, deviceType)
                 })
                 .catch((err) => {


### PR DESCRIPTION
The following PR detects the device type based on its model or its name (in case the first isn't valid), and then setting `deviceType` to `Apple TV` or `iPhone` in the DB. 