### PR TITLE
#849 Display battery and version info. properly

### DIFF
--- a/lib/cli/ios-device/index.js
+++ b/lib/cli/ios-device/index.js
@@ -173,11 +173,6 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: false
   })
-  .option('device-type', {
-    describe: 'Device type'
-    , type: 'string'
-    , default: 'iOS'
-  })
   .option('device-name', {
     describe: 'Device name'
     , type: 'string'

--- a/lib/cli/ios-device/index.js
+++ b/lib/cli/ios-device/index.js
@@ -173,6 +173,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: false
   })
+  .option('device-type', {
+    describe: 'Device type'
+    , type: 'string'
+    , default: 'iOS'
+  })
   .option('device-name', {
     describe: 'Device name'
     , type: 'string'

--- a/lib/units/ios-device/plugins/group.js
+++ b/lib/units/ios-device/plugins/group.js
@@ -120,7 +120,7 @@ module.exports = syrup.serial()
                     ])
 
                   // Store battery info 
-                  if (deviceType !== 'AppleTV') {
+                  if (deviceType !== 'Apple TV') {
                     handleRequest({
                     method: 'GET',
                     uri: `${baseUrl}/session/${sessionId}/wda/batteryInfo`,

--- a/lib/units/ios-device/plugins/group.js
+++ b/lib/units/ios-device/plugins/group.js
@@ -88,7 +88,8 @@ module.exports = syrup.serial()
                     deviceType = "Apple TV"
                   } else {
                     deviceType = "iPhone"
-                  }
+                  }                  
+                  // Store device type
                   log.info('Storing device type value: ' + deviceType)
                   dbapi.setDeviceType(options.serial, deviceType)
                 })
@@ -107,6 +108,43 @@ module.exports = syrup.serial()
               .then((sessionResponse) => {
                 let sessionId = sessionResponse.sessionId
 
+                  // Store device version
+                  log.info('Storing device version')
+                  push.send([
+                    wireutil.global,
+                    wireutil.envelope(new wire.SdkIosVersion(
+                      options.serial,
+                      sessionResponse.value.capabilities.device,
+                      sessionResponse.value.capabilities.sdkVersion,
+                      ))
+                    ])
+
+                  // Store battery info 
+                  handleRequest({
+                    method: 'GET',
+                    uri: `${baseUrl}/session/${sessionId}/wda/batteryInfo`,
+                    json: true,
+                  })
+                  .then((batteryInfoResponse) => {
+                    let batteryState = iosutil.batteryState(batteryInfoResponse.value.state)
+                    let batteryLevel = iosutil.batteryLevel(batteryInfoResponse.value.level)
+                    
+                    push.send([
+                      wireutil.global,
+                      wireutil.envelope(new wire.BatteryIosEvent(
+                        options.serial,
+                        'good',
+                        'usb',
+                        batteryState,
+                        batteryLevel,
+                        'n/a',
+                        100,
+                      ))
+                    ])
+                  })
+                  .catch((err) => log.error('Error storing battery', err))
+
+                // Store size info
                 return handleRequest({
                   method: 'GET',
                   uri: `${baseUrl}/session/${sessionId}/window/size`,

--- a/lib/units/ios-device/plugins/group.js
+++ b/lib/units/ios-device/plugins/group.js
@@ -75,6 +75,7 @@ module.exports = syrup.serial()
             // No device version = First device session 
             if (!device.version) {
               // Get device type
+              let deviceType
               handleRequest({
                 method: 'GET',
                 uri: `${baseUrl}/wda/device/info`,
@@ -83,7 +84,6 @@ module.exports = syrup.serial()
                 .then((deviceInfo) => {
                   let deviceInfoModel = deviceInfo.value.model.toLowerCase()
                   let deviceInfoName = deviceInfo.value.name.toLowerCase()
-                  let deviceType
                   if (deviceInfoModel.includes("tv") || deviceInfoName.includes("tv")) {
                     deviceType = "Apple TV"
                   } else {
@@ -120,7 +120,8 @@ module.exports = syrup.serial()
                     ])
 
                   // Store battery info 
-                  handleRequest({
+                  if (deviceType !== 'AppleTV') {
+                    handleRequest({
                     method: 'GET',
                     uri: `${baseUrl}/session/${sessionId}/wda/batteryInfo`,
                     json: true,
@@ -143,6 +144,7 @@ module.exports = syrup.serial()
                     ])
                   })
                   .catch((err) => log.error('Error storing battery', err))
+                }
 
                 // Store size info
                 return handleRequest({

--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -142,6 +142,28 @@ let iosutil = {
   },
   getUri: function(host, port) {
     return `http://${host}:${port}`
+  },
+  batteryState: function (state) {
+    switch (state) {
+      case 0:
+        return 'full'
+      case 1:
+        return 'unplugged'  
+      case 2: 
+        return 'charging'
+      case 3:
+        return 'full'
+      default:
+        break;
+    }
+  },
+  batteryLevel: function (level) {
+    switch (level) {
+      case -1:
+        return 100
+      default: 
+        return parseInt(level * 100, 10)
+    }
   }
 }
 

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -85,6 +85,7 @@ module.exports = syrup.serial()
                 this.setStatus(3)
                 if (this.deviceType !== 'Apple TV') {
                   this.getOrientation()
+                  this.batteryIosEvent()
                 }
 
                 this.setVersion(sessionResponse)
@@ -505,7 +506,7 @@ module.exports = syrup.serial()
         })
       },
       setVersion: function(currentSession) {
-        log.info('Setting device version: ' + currentSession.value.capabilities.sdkVersion)
+        log.info('Setting current device version: ' + currentSession.value.capabilities.sdkVersion)
 
         push.send([
           wireutil.global,
@@ -592,26 +593,24 @@ module.exports = syrup.serial()
           json: true,
         })
           .then((batteryInfoResponse) => {
-            let status = '-'
-
-            if (batteryInfoResponse.value.state === 3) {
-              status = 'full'
-            }
-            if (batteryInfoResponse.value.state === 2) {
-              status = 'charging'
-            }
+            let batteryState = iosutil.batteryState(batteryInfoResponse.value.state)
+            let batteryLevel = iosutil.batteryLevel(batteryInfoResponse.value.level)
+            
             push.send([
               wireutil.global,
               wireutil.envelope(new wire.BatteryIosEvent(
                 options.serial,
                 'good',
                 'usb',
-                status,
-                parseInt(batteryInfoResponse.value.level * 100, 10),
+                batteryState,
+                batteryLevel,
                 'n/a',
                 100,
               ))
             ])
+          })
+          .then(() => {
+            log.info('Setting new device battery info')
           })
           .catch((err) => log.info(err))
       },


### PR DESCRIPTION
The following PR allows to display battery and version info. after the first device setup. It also improves the `iosutil` with new methods.