### PR TITLE
#973 Move edit icon to left 

### DIFF
--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -740,28 +740,28 @@ function DeviceNoteCell(options) {
     title: options.title
   , defaultOrder: 'asc'
   , build: function() {
-    var td = document.createElement('td')
-    var span = document.createElement('span')
-    var i = document.createElement('i')
+      var td = document.createElement('td')
+      var span = document.createElement('span')
+      var i = document.createElement('i')
 
-    td.className = 'device-note'
-    span.className = 'xeditable-wrapper'
-    span.appendChild(document.createTextNode(''))
+      td.className = 'device-note'
+      span.className = 'xeditable-wrapper'
+      span.appendChild(document.createTextNode(''))
 
-    i.className = 'device-note-edit fa fa-pencil pointer'
+      i.className = 'device-note-edit fa fa-pencil pointer'
 
-    td.appendChild(i)
-    td.appendChild(span)
+      td.appendChild(i)
+      td.appendChild(span)
 
-    return td
-  }
-, update: function(td, item) {
-    var span = td.children[1]
-    var t = span.firstChild
+      return td
+    }
+  , update: function(td, item) {
+      var span = td.children[1]
+      var t = span.firstChild
 
-    t.nodeValue = options.value(item)
-    return td
-  }
+      t.nodeValue = options.value(item)
+      return td
+    }
   , compare: function(a, b) {
       return compareIgnoreCase(options.value(a), options.value(b))
     }

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -740,28 +740,28 @@ function DeviceNoteCell(options) {
     title: options.title
   , defaultOrder: 'asc'
   , build: function() {
-      var td = document.createElement('td')
-      var span = document.createElement('span')
-      var i = document.createElement('i')
+    var td = document.createElement('td')
+    var span = document.createElement('span')
+    var i = document.createElement('i')
 
-      td.className = 'device-note'
-      span.className = 'xeditable-wrapper'
-      span.appendChild(document.createTextNode(''))
+    td.className = 'device-note'
+    span.className = 'xeditable-wrapper'
+    span.appendChild(document.createTextNode(''))
 
-      i.className = 'device-note-edit fa fa-pencil pointer'
+    i.className = 'device-note-edit fa fa-pencil pointer'
 
-      td.appendChild(span)
-      td.appendChild(i)
+    td.appendChild(i)
+    td.appendChild(span)
 
-      return td
-    }
-  , update: function(td, item) {
-      var span = td.firstChild
-      var t = span.firstChild
+    return td
+  }
+, update: function(td, item) {
+    var span = td.children[1]
+    var t = span.firstChild
 
-      t.nodeValue = options.value(item)
-      return td
-    }
+    t.nodeValue = options.value(item)
+    return td
+  }
   , compare: function(a, b) {
       return compareIgnoreCase(options.value(a), options.value(b))
     }

--- a/res/app/device-list/details/device-list-details-directive.js
+++ b/res/app/device-list/details/device-list-details-directive.js
@@ -108,7 +108,7 @@ module.exports = function DeviceListDetailsDirective(
           var i = e.target
           var id = i.parentNode.parentNode.id
           var device = mapping[id]
-          var xeditableWrapper = i.parentNode.firstChild
+          var xeditableWrapper = i.parentNode.querySelector('.xeditable-wrapper')
           var xeditableSpan = document.createElement('span')
           var childScope = scope.$new()
 
@@ -134,11 +134,11 @@ module.exports = function DeviceListDetailsDirective(
         for (var i = 0; i < tr.cells.length; i++) {
           var col = tr.cells[i]
 
-          if (col.firstChild &&
-              col.firstChild.nodeName.toLowerCase() === 'span' &&
-              col.firstChild.classList.contains('xeditable-wrapper')) {
+          if (col.children[1] &&
+            col.children[1].nodeName.toLowerCase() === 'span' &&
+            col.children[1].classList.contains('xeditable-wrapper')) {
 
-            var xeditableWrapper = col.firstChild
+            var xeditableWrapper = col.children[1]
             var children = xeditableWrapper.children
 
             // Remove all childs under xeditablerWrapper

--- a/res/app/device-list/device-list.css
+++ b/res/app/device-list/device-list.css
@@ -80,7 +80,7 @@ img.device-icon-smallest {
 }
 
 .stf-device-list .device-note-edit {
-  margin-left: 15px;
+  margin-right: 15px;
   visibility: hidden;
 }
 


### PR DESCRIPTION
The following PR moves the edit icon to the left side in each note cell.