### PR TITLE
#941 Return last device orientation 

### DIFF
--- a/lib/units/ios-device/plugins/screen/stream.js
+++ b/lib/units/ios-device/plugins/screen/stream.js
@@ -93,27 +93,9 @@ module.exports = syrup.serial()
         ws.on('close', function() {
           // @TODO handle close event
           // stream.socket.onclose()
-            const orientation = WdaClient.orientation
-
-            const stoppingSession = () => {
-              WdaClient.stopSession()
-              isConnectionAlive = false
-              log.important('ws on close event')
-            }
-            
-            if (WdaClient.deviceType === 'Apple TV' || orientation === 'PORTRAIT') {
-              return stoppingSession()
-            } 
-
-            // #770: Reset rotation to Portrait when closing device
-
-            const rotationPromise = new Promise((resolve, reject) => {
-              // Ensure that rotation is done, then stop session
-              WdaClient.rotation({orientation: 'PORTRAIT'})
-              resolve()
-            })
-
-            rotationPromise.delay(2000).then(() => stoppingSession())
+          WdaClient.stopSession()
+          isConnectionAlive = false
+          log.important('ws on close event')
         })
         ws.on('error', function() {
           // @TODO handle error event

--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -124,10 +124,10 @@ let iosutil = {
         }
       case 'LANDSCAPE':
         return {
-          fromX: params.fromX * deviceSize.width,
-          fromY: params.fromY * deviceSize.height,
-          toX: params.toX * deviceSize.width,
-          toY: params.toY * deviceSize.height,
+          fromX: params.fromY * deviceSize.height,
+          fromY: params.fromX * deviceSize.width,
+          toX: params.toY * deviceSize.height,
+          toY: params.toX * deviceSize.width,
           duration: params.duration
         }
       default:

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -334,38 +334,19 @@ module.exports = syrup.serial()
 
           if(((new Date()).getTime() - this.tapStartAt) <= 1000 || !this.tapStartAt) {
 
-            let body 
-
-            if (this.orientation === 'PORTRAIT' || !this.orientation) {
-              body = {
-                actions: [
-                  {
-                    type: 'pointer',
-                    id: 'finger1',
-                    parameters: {pointerType: 'touch'},
-                    actions: [
-                      {type: 'pointerMove', duration: 0, x, y},
-                      {type: 'pointerMove', duration: 0, x, y},
-                      {type: 'pointerUp'},
-                    ],
-                  },
-                ],
-              }
-            } else {
-              body = {
-                actions: [
-                  {
-                    type: 'pointer',
-                    id: 'finger1',
-                    parameters: {pointerType: 'touch'},
-                    actions: [
-                      {type: 'pointerMove', duration: 0, x: y, y: x},
-                      {type: 'pointerMove', duration: 0, x: y, y: x},
-                      {type: 'pointerUp'},
-                    ],
-                  },
-                ],
-              }
+          let body = {
+              actions: [
+                {
+                  type: 'pointer',
+                  id: 'finger1',
+                  parameters: {pointerType: 'touch'},
+                  actions: [
+                    {type: 'pointerMove', duration: 0, x: this.orientation === 'PORTRAIT' ? x : y, y: this.orientation === 'PORTRAIT' ? y : x},
+                    {type: 'pointerMove', duration: 0, x: this.orientation === 'PORTRAIT' ? x : y, y: this.orientation === 'PORTRAIT' ? y : x},
+                    {type: 'pointerUp'},
+                  ],
+                },
+              ],
             }
 
             if (this.deviceType !== 'Apple TV') {

--- a/lib/units/ios-device/plugins/wda/WdaClient.js
+++ b/lib/units/ios-device/plugins/wda/WdaClient.js
@@ -334,7 +334,10 @@ module.exports = syrup.serial()
 
           if(((new Date()).getTime() - this.tapStartAt) <= 1000 || !this.tapStartAt) {
 
-            const body = {
+            let body 
+
+            if (this.orientation === 'PORTRAIT' || !this.orientation) {
+              body = {
                 actions: [
                   {
                     type: 'pointer',
@@ -348,6 +351,22 @@ module.exports = syrup.serial()
                   },
                 ],
               }
+            } else {
+              body = {
+                actions: [
+                  {
+                    type: 'pointer',
+                    id: 'finger1',
+                    parameters: {pointerType: 'touch'},
+                    actions: [
+                      {type: 'pointerMove', duration: 0, x: y, y: x},
+                      {type: 'pointerMove', duration: 0, x: y, y: x},
+                      {type: 'pointerUp'},
+                    ],
+                  },
+                ],
+              }
+            }
 
             if (this.deviceType !== 'Apple TV') {
               log.info(options.deviceName)

--- a/res/app/components/stf/screen/scaling/scaling-service.js
+++ b/res/app/components/stf/screen/scaling/scaling-service.js
@@ -141,13 +141,6 @@ module.exports = function ScalingServiceFactory() {
           w = scaledValue
         }
 
-        if (rotation === 90 && isIosDevice) {
-          return {
-            xP: y / h,
-            yP: x / w
-          }
-        }
-
         return {
           xP: x / w
         , yP: y / h


### PR DESCRIPTION
The following PR will handle the device orientation cases correctly through `WdaClient`, with these changes there's no need to rotate back to portrait when closing/disconnecting the device.