### PR TITLE
#996 Fix for rotation icons styles and exceeded canvas on landscape

### DIFF
--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -476,6 +476,11 @@ module.exports = function DeviceScreenDirective(
 
           if (canvasSizeExceeded()) {
             console.log(`exceeded canvas size limit, reducing previous size: ${canvas.width}x${canvas.height}`);
+            if ($scope.device.display.rotation === 90) {
+              canvas.width = 5376;
+              canvas.height = 2484;
+              return
+            }
             canvas.width = 2484;
             canvas.height = 5376;
           }

--- a/res/app/control-panes/device-control/device-control.pug
+++ b/res/app/control-panes/device-control/device-control.pug
@@ -6,11 +6,11 @@
           .stf-vnc-right-buttons.pull-right
             .btn-group
               label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("portrait")', ng-hide='device.platform === "tvOS"',
-              ng-model='currentRotation', uib-btn-radio='"portrait"',
+              ng-model='currentRotation', uib-btn-radio='"portrait"', id='portrait-label',
               uib-tooltip='{{ "Portrait" | translate }} ({{ "Current rotation:" | translate }} {{ device.display.rotation }}°)', tooltip-placement='bottom').pointer
                 i.fa.fa-mobile
               label.btn-sm.btn-primary-outline(type='button', ng-click='tryToRotate("landscape")', ng-hide='device.platform === "tvOS"',
-                ng-model='currentRotation', uib-btn-radio='"landscape"',
+                ng-model='currentRotation', uib-btn-radio='"landscape"', id='landscape-label',
               uib-tooltip='{{ "Landscape" | translate }} ({{ "Current rotation:" | translate }} {{ device.display.rotation }}°)', tooltip-placement='bottom').pointer
                 i.fa.fa-mobile.fa-rotate-90
             .button-spacer

--- a/res/web_modules/nine-bootstrap/nine-bootstrap.scss
+++ b/res/web_modules/nine-bootstrap/nine-bootstrap.scss
@@ -1118,4 +1118,18 @@ input[type="range"] {
     }
   }
 
+  #portrait-label {
+    &:hover {
+      background: $main;
+      color: #fff
+    }
+  }
+
+  #landscape-label {
+    &:hover {
+      background: $main;
+      color: #fff
+    }
+  }
+
 }


### PR DESCRIPTION
The following PR displays the rotation buttons as active in mobile and switches canvas (if exceeded) size on landscape 