### PR TITLE
#918 using underscores for device name

### DIFF
--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -80,13 +80,17 @@ module.exports = function DeviceColumnService($filter, gettext, SettingsService,
   , model: DeviceModelCell({
       title: gettext('Model')
     , value: function(device) {
-        return device.name || device.model || device.serial
+        const modelText = (device.name || device.model || device.serial).replace(/\s+/g, '_');
+        
+        return modelText
       }
     })
   , name: DeviceNameCell({
       title: gettext('Product')
     , value: function(device) {
-        return device.name || device.model || device.serial
+        const productText = (device.name || device.model || device.serial).replace(/\s+/g, '_');
+
+        return productText
       }
     }, AppState.user.email)
   , platform: TextCell({


### PR DESCRIPTION
The following PR will detect blank spaces and use `_` for product / model columns