### PR TITLE
#1023 possible workaround to use ios18 in mobile

### DIFF
--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -474,7 +474,7 @@ module.exports = function DeviceScreenDirective(
             canvas.height = cachedImageHeight
           }
 
-          if (canvasSizeExceeded()) {
+          if (canvasSizeExceeded() && $scope.device.version !== '18.0') {
             console.log(`exceeded canvas size limit, reducing previous size: ${canvas.width}x${canvas.height}`);
             if ($scope.device.display.rotation === 90) {
               canvas.width = 5376;


### PR DESCRIPTION
The following PR should prevent using a reduced canvas size when using iOS 18 devices