### PR TITLE
#991: Workaround for mobile swipe in iOS

### DIFF
--- a/lib/units/ios-device/plugins/util/iosutil.js
+++ b/lib/units/ios-device/plugins/util/iosutil.js
@@ -113,6 +113,25 @@ let iosutil = {
     }
   },
   swipe: function(orientation, params, deviceSize) {
+
+    if (params.toX >= 2 || params.toY >= 2) {
+      if (params.fromY >= 0.5) {
+        params.fromY /= 2
+        params.toY = 0.25
+      } else {
+        params.fromY *= 2
+        params.toY = 0.75
+      }
+
+      if (params.fromX >= 0.5) {
+        params.fromX /= 2
+        params.toX = 0.25
+      } else {
+        params.fromX *= 2
+        params.toX = 0.75
+      }
+    }
+
     switch(orientation) {
       case 'PORTRAIT':
         return {

--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -1079,9 +1079,13 @@ module.exports = function DeviceScreenDirective(
               $scope.device.ios
             )
 
-            $scope.control.touchMove(nextSeq(), slot, scaled.xP, scaled.yP, pressure)
-            //$scope.control.touchMoveIos(nextSeq(), slot, scaled.xP, scaled.yP, pressure)
-            activateFinger(slot, x, y, pressure)
+            if ($scope.device.ios) {
+              const touchev = e.touches[0];
+
+              $scope.control.touchMoveIos(touchev.pageX, touchev.pageY, scaled.xP, scaled.yP, 0.5);
+            
+              activateFinger(slot, x, y, pressure);
+            }
           }
 
           $scope.control.touchCommit(nextSeq())


### PR DESCRIPTION
The following PR will handle cases where `params.toX` and `params.toY` have big values (swipe made from Mobile), and will adjust their values.