### PR TITLE
#918 Display correct device info. in manufacturer

### DIFF
--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -46,7 +46,7 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
   }
 
   function enhanceDevice(device) {
-    device.enhancedName = device.model || device.product  || device.marketName || device.serial || 'Unknown'
+    device.enhancedName = device.name || device.model || device.product  || device.marketName || device.serial || 'Unknown'
     device.enhancedModel = device.model || 'Unknown'
     device.enhancedImage120 = '/static/app/devices/icon/x120/' + (device.platform || device.image || '_default.jpg')
     device.enhancedImage24 = '/static/app/devices/icon/x24/' + (device.platform || device.image || '_default.jpg')

--- a/res/app/control-panes/info/info.pug
+++ b/res/app/control-panes/info/info.pug
@@ -154,10 +154,10 @@
             div.infocard-table__item {{device.manufacturer}}
           div.infocard-table__row
             div.infocard-table__item(translate) Product
-            div.infocard-table__item {{device.model ? device.model : device.name}}
+            div.infocard-table__item {{device.name ? device.name : device.model}}
           div.infocard-table__row
             div.infocard-table__item(translate) Model
-            div.infocard-table__item {{device.model}}
+            div.infocard-table__item {{device.name ? device.name : device.model}}
           div.infocard-table__row
             div.infocard-table__item(translate) Serial
             div.infocard-table__item {{device.serial}}

--- a/res/app/control-panes/info/info.pug
+++ b/res/app/control-panes/info/info.pug
@@ -154,7 +154,7 @@
             div.infocard-table__item {{device.manufacturer}}
           div.infocard-table__row
             div.infocard-table__item(translate) Product
-            div.infocard-table__item {{device.name ? device.name : '-'}}
+            div.infocard-table__item {{device.model ? device.model : 'device.name'}}
           div.infocard-table__row
             div.infocard-table__item(translate) Model
             div.infocard-table__item {{device.model}}

--- a/res/app/control-panes/info/info.pug
+++ b/res/app/control-panes/info/info.pug
@@ -154,7 +154,7 @@
             div.infocard-table__item {{device.manufacturer}}
           div.infocard-table__row
             div.infocard-table__item(translate) Product
-            div.infocard-table__item {{device.model ? device.model : 'device.name'}}
+            div.infocard-table__item {{device.model ? device.model : device.name}}
           div.infocard-table__row
             div.infocard-table__item(translate) Model
             div.infocard-table__item {{device.model}}


### PR DESCRIPTION
The following PR will display the `device.model` value in Product. If there's no value, it will use `device.name`.